### PR TITLE
Remove namespace ambiguities

### DIFF
--- a/src/qamqpauthenticator.cpp
+++ b/src/qamqpauthenticator.cpp
@@ -1,7 +1,8 @@
 #include "qamqptable.h"
 #include "qamqpframe_p.h"
 #include "qamqpauthenticator.h"
-using namespace QAMQP;
+
+namespace QAMQP {
 
 AMQPlainAuthenticator::AMQPlainAuthenticator(const QString &l, const QString &p)
     : login_(l),
@@ -46,3 +47,5 @@ void AMQPlainAuthenticator::write(QDataStream &out)
     response["PASSWORD"] = password_;
     out << response;
 }
+
+} // namespace QAMQP

--- a/src/qamqpchannel.cpp
+++ b/src/qamqpchannel.cpp
@@ -6,7 +6,7 @@
 #include <QDebug>
 #include <QDataStream>
 
-using namespace QAMQP;
+namespace QAMQP {
 
 int ChannelPrivate::nextChannelNumber = 0;
 ChannelPrivate::ChannelPrivate(Channel *q)
@@ -336,5 +336,7 @@ void Channel::resume()
     Q_D(Channel);
     d->flow(true);
 }
+
+} // namespace QAMQP
 
 #include "moc_qamqpchannel.cpp"

--- a/src/qamqpclient.cpp
+++ b/src/qamqpclient.cpp
@@ -13,7 +13,8 @@
 #include "qamqptable.h"
 #include "qamqpclient_p.h"
 #include "qamqpclient.h"
-using namespace QAMQP;
+
+namespace QAMQP {
 
 ClientPrivate::ClientPrivate(Client *q)
     : port(AMQP_PORT),
@@ -841,6 +842,8 @@ SslClient::~SslClient()
 {
 }
 
-#endif
+#endif // QT_NO_SSL
+
+} // namespace QAMQP
 
 #include "moc_qamqpclient.cpp"

--- a/src/qamqpexchange.cpp
+++ b/src/qamqpexchange.cpp
@@ -6,7 +6,8 @@
 #include "qamqpqueue.h"
 #include "qamqpglobal.h"
 #include "qamqpclient.h"
-using namespace QAMQP;
+
+namespace QAMQP {
 
 QString ExchangePrivate::typeToString(Exchange::ExchangeType type)
 {
@@ -269,3 +270,5 @@ void Exchange::publish(const QByteArray &message, const QString &routingKey,
         d->sendFrame(body);
     }
 }
+
+} // namespace QAMQP

--- a/src/qamqpframe.cpp
+++ b/src/qamqpframe.cpp
@@ -6,8 +6,8 @@
 #include "qamqpglobal.h"
 #include "qamqpframe_p.h"
 
-using namespace QAMQP;
-using namespace QAMQP::Frame;
+namespace QAMQP {
+namespace Frame {
 
 Base::Base(Type type)
     : size_(0),
@@ -139,7 +139,7 @@ void Method::writePayload(QDataStream &stream) const
 
 //////////////////////////////////////////////////////////////////////////
 
-QVariant Frame::readAmqpField(QDataStream &s, MetaType::ValueType type)
+QVariant readAmqpField(QDataStream &s, MetaType::ValueType type)
 {
     switch (type) {
     case MetaType::Boolean:
@@ -213,7 +213,7 @@ QVariant Frame::readAmqpField(QDataStream &s, MetaType::ValueType type)
     return QVariant();
 }
 
-void Frame::writeAmqpField(QDataStream &s, MetaType::ValueType type, const QVariant &value)
+void writeAmqpField(QDataStream &s, MetaType::ValueType type, const QVariant &value)
 {
     switch (type) {
     case MetaType::Boolean:
@@ -475,3 +475,6 @@ void Heartbeat::writePayload(QDataStream &stream) const
 {
     Q_UNUSED(stream)
 }
+
+} // namespace Frame
+} // namespace QAMQP

--- a/src/qamqpmessage.cpp
+++ b/src/qamqpmessage.cpp
@@ -2,7 +2,8 @@
 
 #include "qamqpmessage.h"
 #include "qamqpmessage_p.h"
-using namespace QAMQP;
+
+namespace QAMQP {
 
 MessagePrivate::MessagePrivate()
     : deliveryTag(0),
@@ -115,6 +116,8 @@ bool Message::isDetached() const
     return d && d->ref == 1;
 }
 #endif
+
+} // namespace QAMQP
 
 uint qHash(const QAMQP::Message &message, uint seed)
 {

--- a/src/qamqpqueue.cpp
+++ b/src/qamqpqueue.cpp
@@ -8,7 +8,8 @@
 #include "qamqpexchange.h"
 #include "qamqpmessage_p.h"
 #include "qamqptable.h"
-using namespace QAMQP;
+
+namespace QAMQP {
 
 QueuePrivate::QueuePrivate(Queue *q)
     : ChannelPrivate(q),
@@ -549,4 +550,4 @@ bool Queue::cancel(bool noWait)
     return true;
 }
 
-#include "moc_qamqpqueue.cpp"
+} // namespace QAMQP

--- a/src/qamqptable.cpp
+++ b/src/qamqptable.cpp
@@ -5,7 +5,9 @@
 
 #include "qamqpframe_p.h"
 #include "qamqptable.h"
-using namespace QAMQP;
+
+namespace QAMQP {
+namespace {
 
 /*
  * field value types according to: https://www.rabbitmq.com/amqp-0-9-1-errata.html
@@ -76,6 +78,8 @@ qint8 valueTypeToOctet(MetaType::ValueType type)
 
     return 'V';
 }
+
+} // namespace
 
 void Table::writeFieldValue(QDataStream &stream, const QVariant &value)
 {
@@ -335,15 +339,17 @@ QVariant Table::readFieldValue(QDataStream &stream, MetaType::ValueType type)
     return QVariant();
 }
 
-QDataStream &operator<<(QDataStream &stream, const Table &table)
+} // namespace QAMQP
+
+QDataStream &operator<<(QDataStream &stream, const QAMQP::Table &table)
 {
     QByteArray data;
     QDataStream s(&data, QIODevice::WriteOnly);
-    Table::ConstIterator it;
-    Table::ConstIterator itEnd = table.constEnd();
+    QAMQP::Table::ConstIterator it;
+    QAMQP::Table::ConstIterator itEnd = table.constEnd();
     for (it = table.constBegin(); it != itEnd; ++it) {
-        Table::writeFieldValue(s, MetaType::ShortString, it.key());
-        Table::writeFieldValue(s, it.value());
+        QAMQP::Table::writeFieldValue(s, QAMQP::MetaType::ShortString, it.key());
+        QAMQP::Table::writeFieldValue(s, it.value());
     }
 
     if (data.isEmpty()) {
@@ -355,16 +361,16 @@ QDataStream &operator<<(QDataStream &stream, const Table &table)
     return stream;
 }
 
-QDataStream &operator>>(QDataStream &stream, Table &table)
+QDataStream &operator>>(QDataStream &stream, QAMQP::Table &table)
 {
     QByteArray data;
     stream >> data;
     QDataStream tableStream(&data, QIODevice::ReadOnly);
     while (!tableStream.atEnd()) {
         qint8 octet = 0;
-        QString field = Frame::readAmqpField(tableStream, MetaType::ShortString).toString();
+        QString field = QAMQP::Frame::readAmqpField(tableStream, QAMQP::MetaType::ShortString).toString();
         tableStream >> octet;
-        table[field] = Table::readFieldValue(tableStream, valueTypeForOctet(octet));
+        table[field] = QAMQP::Table::readFieldValue(tableStream, QAMQP::valueTypeForOctet(octet));
     }
 
     return stream;


### PR DESCRIPTION
Using constructs such as,
   using namespace QAMQP;
is not the best way of defining symbols in those namespaces.
