### PR TITLE
remove QAMQP namespace

### DIFF
--- a/src/qamqpauthenticator.cpp
+++ b/src/qamqpauthenticator.cpp
@@ -1,47 +1,46 @@
 #include "qamqptable.h"
 #include "qamqpframe_p.h"
 #include "qamqpauthenticator.h"
-using namespace QAMQP;
 
-AMQPlainAuthenticator::AMQPlainAuthenticator(const QString &l, const QString &p)
+QAmqpPlainAuthenticator::QAmqpPlainAuthenticator(const QString &l, const QString &p)
     : login_(l),
       password_(p)
 {
 }
 
-AMQPlainAuthenticator::~AMQPlainAuthenticator()
+QAmqpPlainAuthenticator::~QAmqpPlainAuthenticator()
 {
 }
 
-QString AMQPlainAuthenticator::login() const
+QString QAmqpPlainAuthenticator::login() const
 {
     return login_;
 }
 
-QString AMQPlainAuthenticator::password() const
+QString QAmqpPlainAuthenticator::password() const
 {
     return password_;
 }
 
-QString AMQPlainAuthenticator::type() const
+QString QAmqpPlainAuthenticator::type() const
 {
     return "AMQPLAIN";
 }
 
-void AMQPlainAuthenticator::setLogin(const QString &l)
+void QAmqpPlainAuthenticator::setLogin(const QString &l)
 {
     login_ = l;
 }
 
-void AMQPlainAuthenticator::setPassword(const QString &p)
+void QAmqpPlainAuthenticator::setPassword(const QString &p)
 {
     password_ = p;
 }
 
-void AMQPlainAuthenticator::write(QDataStream &out)
+void QAmqpPlainAuthenticator::write(QDataStream &out)
 {
-    Frame::writeAmqpField(out, MetaType::ShortString, type());
-    Table response;
+    QAmqpFrame::writeAmqpField(out, QAmqpMetaType::ShortString, type());
+    QAmqpTable response;
     response["LOGIN"] = login_;
     response["PASSWORD"] = password_;
     out << response;

--- a/src/qamqpauthenticator.h
+++ b/src/qamqpauthenticator.h
@@ -6,22 +6,19 @@
 
 #include "qamqpglobal.h"
 
-namespace QAMQP
-{
-
-class QAMQP_EXPORT Authenticator
+class QAMQP_EXPORT QAmqpAuthenticator
 {
 public:
-    virtual ~Authenticator() {}
+    virtual ~QAmqpAuthenticator() {}
     virtual QString type() const = 0;
     virtual void write(QDataStream &out) = 0;
 };
 
-class QAMQP_EXPORT AMQPlainAuthenticator : public Authenticator
+class QAMQP_EXPORT QAmqpPlainAuthenticator : public QAmqpAuthenticator
 {
 public:
-    AMQPlainAuthenticator(const QString &login = QString(), const QString &password = QString());
-    virtual ~AMQPlainAuthenticator();
+    QAmqpPlainAuthenticator(const QString &login = QString(), const QString &password = QString());
+    virtual ~QAmqpPlainAuthenticator();
 
     QString login() const;
     void setLogin(const QString &l);
@@ -37,7 +34,5 @@ private:
     QString password_;
 
 };
-
-} // namespace QAMQP
 
 #endif // QAMQPAUTHENTICATOR_H

--- a/src/qamqpchannel.h
+++ b/src/qamqpchannel.h
@@ -4,19 +4,16 @@
 #include <QObject>
 #include "qamqpglobal.h"
 
-namespace QAMQP
-{
-
-class Client;
-class ChannelPrivate;
-class QAMQP_EXPORT Channel : public QObject
+class QAmqpClient;
+class QAmqpChannelPrivate;
+class QAMQP_EXPORT QAmqpChannel : public QObject
 {
     Q_OBJECT
     Q_PROPERTY(int number READ channelNumber CONSTANT)
     Q_PROPERTY(bool opened READ isOpened CONSTANT)
     Q_PROPERTY(QString name READ name WRITE setName)
 public:
-    virtual ~Channel();
+    virtual ~QAmqpChannel();
 
     int channelNumber() const;
     bool isOpened() const;
@@ -24,7 +21,7 @@ public:
     QString name() const;
     void setName(const QString &name);
 
-    Error error() const;
+    QAMQP::Error error() const;
     QString errorString() const;
 
     qint32 prefetchSize() const;
@@ -51,18 +48,16 @@ protected:
     virtual void channelClosed() = 0;
 
 protected:
-    explicit Channel(ChannelPrivate *dd, Client *client);
+    explicit QAmqpChannel(QAmqpChannelPrivate *dd, QAmqpClient *client);
 
-    Q_DISABLE_COPY(Channel)
-    Q_DECLARE_PRIVATE(Channel)
-    QScopedPointer<ChannelPrivate> d_ptr;
+    Q_DISABLE_COPY(QAmqpChannel)
+    Q_DECLARE_PRIVATE(QAmqpChannel)
+    QScopedPointer<QAmqpChannelPrivate> d_ptr;
 
     Q_PRIVATE_SLOT(d_func(), void _q_open())
     Q_PRIVATE_SLOT(d_func(), void _q_disconnected())
 
-    friend class ClientPrivate;
+    friend class QAmqpClientPrivate;
 };
-
-} // namespace QAMQP
 
 #endif  // QAMQPCHANNEL_H

--- a/src/qamqpchannel_p.h
+++ b/src/qamqpchannel_p.h
@@ -6,13 +6,9 @@
 
 #define METHOD_ID_ENUM(name, id) name = id, name ## Ok
 
-namespace QAMQP
-{
-
-class Client;
-class Network;
-class ClientPrivate;
-class ChannelPrivate : public Frame::MethodHandler
+class QAmqpClient;
+class QAmqpClientPrivate;
+class QAmqpChannelPrivate : public QAmqpMethodFrameHandler
 {
 public:
     enum MethodId {
@@ -36,11 +32,11 @@ public:
         METHOD_ID_ENUM(bmRecover, 110)
     };
 
-    ChannelPrivate(Channel *q);
-    virtual ~ChannelPrivate();
+    QAmqpChannelPrivate(QAmqpChannel *q);
+    virtual ~QAmqpChannelPrivate();
 
-    void init(int channel, Client *client);
-    void sendFrame(const Frame::Base &frame);
+    void init(int channel, QAmqpClient *client);
+    void sendFrame(const QAmqpFrame &frame);
 
     void open();
     void flow(bool active);
@@ -48,19 +44,19 @@ public:
     void close(int code, const QString &text, int classId, int methodId);
 
     // reimp MethodHandler
-    virtual bool _q_method(const Frame::Method &frame);
-    void openOk(const Frame::Method &frame);
-    void flow(const Frame::Method &frame);
-    void flowOk(const Frame::Method &frame);
-    void close(const Frame::Method &frame);
-    void closeOk(const Frame::Method &frame);
-    void qosOk(const Frame::Method &frame);
+    virtual bool _q_method(const QAmqpMethodFrame &frame);
+    void openOk(const QAmqpMethodFrame &frame);
+    void flow(const QAmqpMethodFrame &frame);
+    void flowOk(const QAmqpMethodFrame &frame);
+    void close(const QAmqpMethodFrame &frame);
+    void closeOk(const QAmqpMethodFrame &frame);
+    void qosOk(const QAmqpMethodFrame &frame);
 
     // private slots
     virtual void _q_disconnected();
     void _q_open();
 
-    QPointer<Client> client;
+    QPointer<QAmqpClient> client;
     QString name;
     int channelNumber;
     static int nextChannelNumber;
@@ -72,13 +68,11 @@ public:
     qint16 prefetchCount;
     qint16 requestedPrefetchCount;
 
-    Error error;
+    QAMQP::Error error;
     QString errorString;
 
-    Q_DECLARE_PUBLIC(Channel)
-    Channel * const q_ptr;
+    Q_DECLARE_PUBLIC(QAmqpChannel)
+    QAmqpChannel * const q_ptr;
 };
-
-} // namespace QAMQP
 
 #endif // QAMQPCHANNEL_P_H

--- a/src/qamqpclient.h
+++ b/src/qamqpclient.h
@@ -12,14 +12,11 @@
 
 #include "qamqpglobal.h"
 
-namespace QAMQP
-{
-
-class Exchange;
-class Queue;
-class Authenticator;
-class ClientPrivate;
-class QAMQP_EXPORT Client : public QObject
+class QAmqpExchange;
+class QAmqpQueue;
+class QAmqpAuthenticator;
+class QAmqpClientPrivate;
+class QAMQP_EXPORT QAmqpClient : public QObject
 {
     Q_OBJECT
     Q_PROPERTY(quint32 port READ port WRITE setPort)
@@ -33,8 +30,8 @@ class QAMQP_EXPORT Client : public QObject
     Q_PROPERTY(qint16 heartbeatDelay READ heartbeatDelay() WRITE setHeartbeatDelay)
 
 public:
-    explicit Client(QObject *parent = 0);
-    ~Client();
+    explicit QAmqpClient(QObject *parent = 0);
+    ~QAmqpClient();
 
     // properties
     quint16 port() const;
@@ -52,8 +49,8 @@ public:
     QString password() const;
     void setPassword(const QString &password);
 
-    void setAuth(Authenticator *auth);
-    Authenticator *auth() const;
+    void setAuth(QAmqpAuthenticator *auth);
+    QAmqpAuthenticator *auth() const;
 
     bool autoReconnect() const;
     void setAutoReconnect(bool value);
@@ -72,15 +69,15 @@ public:
     void addCustomProperty(const QString &name, const QString &value);
     QString customProperty(const QString &name) const;
 
-    Error error() const;
+    QAMQP::Error error() const;
     QString errorString() const;
 
     // channels
-    Exchange *createExchange(int channelNumber = -1);
-    Exchange *createExchange(const QString &name, int channelNumber = -1);
+    QAmqpExchange *createExchange(int channelNumber = -1);
+    QAmqpExchange *createExchange(const QString &name, int channelNumber = -1);
 
-    Queue *createQueue(int channelNumber = -1);
-    Queue *createQueue(const QString &name, int channelNumber = -1);
+    QAmqpQueue *createQueue(int channelNumber = -1);
+    QAmqpQueue *createQueue(const QString &name, int channelNumber = -1);
 
     // methods
     void connectToHost(const QString &uri = QString());
@@ -93,11 +90,11 @@ Q_SIGNALS:
     void error(QAMQP::Error error);
 
 protected:
-    Client(ClientPrivate *dd, QObject *parent = 0);
+    QAmqpClient(QAmqpClientPrivate *dd, QObject *parent = 0);
 
-    Q_DISABLE_COPY(Client)
-    Q_DECLARE_PRIVATE(Client)
-    QScopedPointer<ClientPrivate> d_ptr;
+    Q_DISABLE_COPY(QAmqpClient)
+    Q_DECLARE_PRIVATE(QAmqpClient)
+    QScopedPointer<QAmqpClientPrivate> d_ptr;
 
 private:
     Q_PRIVATE_SLOT(d_func(), void _q_socketConnected())
@@ -108,32 +105,30 @@ private:
     Q_PRIVATE_SLOT(d_func(), void _q_connect())
     Q_PRIVATE_SLOT(d_func(), void _q_disconnect())
 
-    friend class ChannelPrivate;
+    friend class QAmqpChannelPrivate;
 
 };
 
 #ifndef QT_NO_SSL
-class SslClientPrivate;
-class SslClient : public Client
+class QAmqpSslClientPrivate;
+class QAmqpSslClient : public QAmqpClient
 {
     Q_OBJECT
 public:
-    SslClient(QObject *parent = 0);
-    SslClient(const QUrl &connectionString, QObject *parent = 0);
-    ~SslClient();
+    QAmqpSslClient(QObject *parent = 0);
+    QAmqpSslClient(const QUrl &connectionString, QObject *parent = 0);
+    ~QAmqpSslClient();
 
     QSslConfiguration sslConfiguration() const;
     void setSslConfiguration(const QSslConfiguration &config);
 
 private:
-    Q_DISABLE_COPY(SslClient)
-    Q_DECLARE_PRIVATE(SslClient)
+    Q_DISABLE_COPY(QAmqpSslClient)
+    Q_DECLARE_PRIVATE(QAmqpSslClient)
 
     Q_PRIVATE_SLOT(d_func(), void _q_sslErrors(const QList<QSslError> &errors))
 
 };
 #endif
-
-} // namespace QAMQP
 
 #endif // QAMQPCLIENT_H

--- a/src/qamqpclient_p.h
+++ b/src/qamqpclient_p.h
@@ -20,16 +20,12 @@
 
 class QTimer;
 class QTcpSocket;
-namespace QAMQP
-{
-
-class Client;
-class Queue;
-class Exchange;
-class Network;
-class Connection;
-class Authenticator;
-class QAMQP_EXPORT ClientPrivate : public Frame::MethodHandler
+class QAmqpClient;
+class QAmqpQueue;
+class QAmqpExchange;
+class QAmqpConnection;
+class QAmqpAuthenticator;
+class QAMQP_EXPORT QAmqpClientPrivate : public QAmqpMethodFrameHandler
 {
 public:
     enum MethodId {
@@ -40,15 +36,15 @@ public:
         METHOD_ID_ENUM(miClose, 50)
     };
 
-    ClientPrivate(Client *q);
-    virtual ~ClientPrivate();
+    QAmqpClientPrivate(QAmqpClient *q);
+    virtual ~QAmqpClientPrivate();
 
     virtual void init();
     virtual void initSocket();
     void setUsername(const QString &username);
     void setPassword(const QString &password);
     void parseConnectionString(const QString &uri);
-    void sendFrame(const Frame::Base &frame);
+    void sendFrame(const QAmqpFrame &frame);
 
     // private slots
     void _q_socketConnected();
@@ -59,14 +55,14 @@ public:
     virtual void _q_connect();
     void _q_disconnect();
 
-    virtual bool _q_method(const Frame::Method &frame);
+    virtual bool _q_method(const QAmqpMethodFrame &frame);
 
     // method handlers, FROM server
-    void start(const Frame::Method &frame);
-    void secure(const Frame::Method &frame);
-    void tune(const Frame::Method &frame);
-    void openOk(const Frame::Method &frame);
-    void closeOk(const Frame::Method &frame);
+    void start(const QAmqpMethodFrame &frame);
+    void secure(const QAmqpMethodFrame &frame);
+    void tune(const QAmqpMethodFrame &frame);
+    void openOk(const QAmqpMethodFrame &frame);
+    void closeOk(const QAmqpMethodFrame &frame);
 
     // method handlers, TO server
     void startOk();
@@ -76,13 +72,13 @@ public:
 
     // method handlers, BOTH ways
     void close(int code, const QString &text, int classId = 0, int methodId = 0);
-    void close(const Frame::Method &frame);
+    void close(const QAmqpMethodFrame &frame);
 
     quint16 port;
     QString host;
     QString virtualHost;
 
-    QSharedPointer<Authenticator> authenticator;
+    QSharedPointer<QAmqpAuthenticator> authenticator;
 
     // Network
     QByteArray buffer;
@@ -91,33 +87,33 @@ public:
     bool connecting;
     QTcpSocket *socket;
 
-    QHash<quint16, QList<Frame::MethodHandler*> > methodHandlersByChannel;
-    QHash<quint16, QList<Frame::ContentHandler*> > contentHandlerByChannel;
-    QHash<quint16, QList<Frame::ContentBodyHandler*> > bodyHandlersByChannel;
+    QHash<quint16, QList<QAmqpMethodFrameHandler*> > methodHandlersByChannel;
+    QHash<quint16, QList<QAmqpContentFrameHandler*> > contentHandlerByChannel;
+    QHash<quint16, QList<QAmqpContentBodyFrameHandler*> > bodyHandlersByChannel;
 
     // Connection
     bool closed;
     bool connected;
     QPointer<QTimer> heartbeatTimer;
-    Table customProperties;
+    QAmqpTable customProperties;
     qint16 channelMax;
     qint16 heartbeatDelay;
     qint32 frameMax;
 
-    Error error;
+    QAMQP::Error error;
     QString errorString;
 
-    Client * const q_ptr;
-    Q_DECLARE_PUBLIC(Client)
+    QAmqpClient * const q_ptr;
+    Q_DECLARE_PUBLIC(QAmqpClient)
 
 };
 
 #ifndef QT_NO_SSL
-class SslClient;
-class SslClientPrivate : public ClientPrivate
+class QAmqpSslClient;
+class QAmqpSslClientPrivate : public QAmqpClientPrivate
 {
 public:
-    SslClientPrivate(SslClient *q);
+    QAmqpSslClientPrivate(QAmqpSslClient *q);
 
     virtual void initSocket();
     virtual void _q_connect();
@@ -129,7 +125,5 @@ public:
 
 };
 #endif
-
-} // namespace QAMQP
 
 #endif // QAMQPCLIENT_P_H

--- a/src/qamqpexchange.h
+++ b/src/qamqpexchange.h
@@ -5,14 +5,11 @@
 #include "qamqpchannel.h"
 #include "qamqpmessage.h"
 
-namespace QAMQP
-{
-
-class Client;
-class Queue;
-class ClientPrivate;
-class ExchangePrivate;
-class QAMQP_EXPORT Exchange : public Channel
+class QAmqpClient;
+class QAmqpQueue;
+class QAmqpClientPrivate;
+class QAmqpExchangePrivate;
+class QAMQP_EXPORT QAmqpExchange : public QAmqpChannel
 {
     Q_OBJECT
     Q_PROPERTY(QString type READ type CONSTANT)
@@ -53,27 +50,27 @@ public:
     Q_DECLARE_FLAGS(ExchangeOptions, ExchangeOption)
     ExchangeOptions options() const;
 
-    virtual ~Exchange();
+    virtual ~QAmqpExchange();
 
     // AMQP Exchange
     void declare(ExchangeType type = Direct,
                  ExchangeOptions options = NoOptions,
-                 const Table &args = Table());
+                 const QAmqpTable &args = QAmqpTable());
     void declare(const QString &type = QLatin1String("direct"),
                  ExchangeOptions options = NoOptions,
-                 const Table &args = Table());
+                 const QAmqpTable &args = QAmqpTable());
     void remove(int options = roIfUnused|roNoWait);
 
     // AMQP Basic
     void publish(const QString &message, const QString &routingKey,
-                 const Message::PropertyHash &properties = Message::PropertyHash(),
+                 const QAmqpMessage::PropertyHash &properties = QAmqpMessage::PropertyHash(),
                  int publishOptions = poNoOptions);
     void publish(const QByteArray &message, const QString &routingKey, const QString &mimeType,
-                 const Message::PropertyHash &properties = Message::PropertyHash(),
+                 const QAmqpMessage::PropertyHash &properties = QAmqpMessage::PropertyHash(),
                  int publishOptions = poNoOptions);
     void publish(const QByteArray &message, const QString &routingKey,
-                 const QString &mimeType, const Table &headers,
-                 const Message::PropertyHash &properties = Message::PropertyHash(),
+                 const QString &mimeType, const QAmqpTable &headers,
+                 const QAmqpMessage::PropertyHash &properties = QAmqpMessage::PropertyHash(),
                  int publishOptions = poNoOptions);
 
 Q_SIGNALS:
@@ -85,18 +82,16 @@ protected:
     virtual void channelClosed();
 
 private:
-    explicit Exchange(int channelNumber = -1, Client *parent = 0);
+    explicit QAmqpExchange(int channelNumber = -1, QAmqpClient *parent = 0);
 
-    Q_DISABLE_COPY(Exchange)
-    Q_DECLARE_PRIVATE(Exchange)
+    Q_DISABLE_COPY(QAmqpExchange)
+    Q_DECLARE_PRIVATE(QAmqpExchange)
 
-    friend class Client;
+    friend class QAmqpClient;
 
 };
 
-} // namespace QAMQP
-
-Q_DECLARE_OPERATORS_FOR_FLAGS(QAMQP::Exchange::ExchangeOptions)
-Q_DECLARE_METATYPE(QAMQP::Exchange::ExchangeType)
+Q_DECLARE_OPERATORS_FOR_FLAGS(QAmqpExchange::ExchangeOptions)
+Q_DECLARE_METATYPE(QAmqpExchange::ExchangeType)
 
 #endif // QAMQPEXCHANGE_H

--- a/src/qamqpexchange_p.h
+++ b/src/qamqpexchange_p.h
@@ -5,10 +5,7 @@
 #include "qamqpexchange.h"
 #include "qamqpchannel_p.h"
 
-namespace QAMQP
-{
-
-class ExchangePrivate: public ChannelPrivate
+class QAmqpExchangePrivate: public QAmqpChannelPrivate
 {
 public:
     enum MethodId {
@@ -16,27 +13,25 @@ public:
         METHOD_ID_ENUM(miDelete, 20)
     };
 
-    ExchangePrivate(Exchange *q);
-    static QString typeToString(Exchange::ExchangeType type);
+    QAmqpExchangePrivate(QAmqpExchange *q);
+    static QString typeToString(QAmqpExchange::ExchangeType type);
 
     void declare();
 
     // method handler related
     virtual void _q_disconnected();
-    virtual bool _q_method(const Frame::Method &frame);
-    void declareOk(const Frame::Method &frame);
-    void deleteOk(const Frame::Method &frame);
-    void basicReturn(const Frame::Method &frame);
+    virtual bool _q_method(const QAmqpMethodFrame &frame);
+    void declareOk(const QAmqpMethodFrame &frame);
+    void deleteOk(const QAmqpMethodFrame &frame);
+    void basicReturn(const QAmqpMethodFrame &frame);
 
     QString type;
-    Exchange::ExchangeOptions options;
-    Table arguments;
+    QAmqpExchange::ExchangeOptions options;
+    QAmqpTable arguments;
     bool delayedDeclare;
     bool declared;
 
-    Q_DECLARE_PUBLIC(Exchange)
+    Q_DECLARE_PUBLIC(QAmqpExchange)
 };
-
-} // namespace QAMQP
 
 #endif // QAMQPEXCHANGE_P_H

--- a/src/qamqpframe_p.h
+++ b/src/qamqpframe_p.h
@@ -8,18 +8,16 @@
 #include "qamqpglobal.h"
 #include "qamqpmessage.h"
 
+class QAmqpQueuePrivate;
+
 /**
  *  Library namespace
  *  @namespace QAMQP
  */
-namespace QAMQP
-{
 
-class QueuePrivate;
-namespace Frame
+class QAmqpFrame
 {
-    typedef quint16 channel_t;
-
+public:
     /*
      * @brief Header size in bytes
      */
@@ -60,8 +58,8 @@ namespace Frame
         fcTx = 90,
     };
 
-    QVariant readAmqpField(QDataStream &s, MetaType::ValueType type);
-    void writeAmqpField(QDataStream &s, MetaType::ValueType type, const QVariant &value);
+    static QVariant readAmqpField(QDataStream &s, QAmqpMetaType::ValueType type);
+    static void writeAmqpField(QDataStream &s, QAmqpMetaType::ValueType type, const QVariant &value);
 
     /*
      * @brief Base class for any frames.
@@ -76,286 +74,279 @@ namespace Frame
      *   @endcode
      *   octet short long 'size' octets octet
      */
-    class QAMQP_EXPORT Base
-    {
-    public:
-        /*
-         * Base class constructor.
-         * @detailed Construct frame class for sending.
-         * @param type Define type of constructed frame.
-         */
-        Base(Type type);
-
-        /*
-         * Base class constructor.
-         * @detailed Construct frame class from received raw data.
-         * @param raw Data stream for reading source data.
-         */
-        Base(QDataStream &raw);
-
-        /*
-         * Base class virtual destructor
-         */
-        virtual ~Base();
-
-        /*
-         * Frame type
-         * @detailed Return type of current frame.
-         */
-        Type type() const;
-
-        /*
-         * Set number of associated channel.
-         * @param channel Number of channel.
-         * @sa channel()
-         */
-        void setChannel(qint16 channel);
-
-        /*
-         * Return number of associated channel.
-         * @sa setChannel()
-         */
-        qint16 channel() const;
-
-        /*
-         * Return size of frame.
-         */
-        virtual qint32 size() const;
-
-        /*
-         * Output frame to stream.
-         * @param stream Stream for serilize frame.
-         */
-        void toStream(QDataStream &stream) const;
-
-    protected:
-        void writeHeader(QDataStream &stream) const;
-        virtual void writePayload(QDataStream &stream) const = 0;
-        void writeEnd(QDataStream &stream) const;
-
-        void readHeader(QDataStream &stream);
-        virtual void readPayload(QDataStream &stream) = 0;
-        // void readEnd(QDataStream &stream);
-
-        qint32 size_;
-
-    private:
-        qint8 type_;
-        qint16 channel_;
-
-    };
 
     /*
-     * @brief Class for working with method frames.
-     * @detailed Implement main methods for serialize and deserialize raw method frame data.
-     * Method frame bodies consist of an invariant list of data fields, called "arguments". All method bodies start
-     * with identifier numbers for the class and method:
-     * @code Frame struct
-     * 0		   2		   4
-     * +----------+-----------+-------------- - -
-     * | class-id | method-id | arguments...
-     * +----------+-----------+-------------- - -
-     *     short	  short	...
-     * @endcode
+     * Base class constructor.
+     * @detailed Construct frame class for sending.
+     * @param type Define type of constructed frame.
      */
-    class QAMQP_EXPORT Method : public Base
-    {
-    public:
-        /*
-         * Method class constructor.
-         * @detailed Construct frame class for sending.
-         * @param methodClass Define method class id of constructed frame.
-         * @param id Define method id of constructed frame.
-         */
-        explicit Method(MethodClass methodClass, qint16 id);
-
-        /*
-         * Method class constructor.
-         * @detailed Construct frame class from received raw data.
-         * @param raw Data stream for reading source data.
-         */
-        explicit Method(QDataStream &raw);
-
-        /*
-         * Method class type.
-         */
-        MethodClass methodClass() const;
-
-        /*
-         * Method id.
-         */
-        qint16 id() const;
-        qint32 size() const;
-
-        /*
-         * Set arguments for method.
-         * @param data Serialized method arguments.
-         * @sa arguments
-         */
-        void setArguments(const QByteArray &data);
-
-        /*
-         * Return arguments for method.
-         * @sa setArguments
-         */
-        QByteArray arguments() const;
-
-    protected:
-        void writePayload(QDataStream &stream) const;
-        void readPayload(QDataStream &stream);
-        short methodClass_;
-        qint16 id_;
-        QByteArray arguments_;
-
-    };
+    QAmqpFrame(Type type);
 
     /*
-     * @brief Class for working with content frames.
-     * @detailed Implement main methods for serialize and deserialize raw content frame data.
-     * A content header payload has this format:
-     * @code Frame struct
-     * +----------+--------+-----------+----------------+------------- - -
-     * | class-id | weight | body size | property flags | property list...
-     * +----------+--------+-----------+----------------+------------- - -
-     *     short     short   long long       short          remainder...
-     * @endcode
-     *
-     * | Property         | Description                            |
-     * | ---------------- | -------------------------------------- |
-     * | ContentType      | MIME content type                      |
-     * | ContentEncoding  | MIME content encoding                  |
-     * | Headers          | message header field table             |
-     * | DeliveryMode     | nonpersistent (1) or persistent (2)    |
-     * | Priority         | message priority, 0 to 9               |
-     * | CorrelationId    | application correlation identifier     |
-     * | ReplyTo          | address to reply to                    |
-     * | Expiration       | message expiration specification       |
-     * | MessageId        | application message identifier         |
-     * | Timestamp        | message timestamp                      |
-     * | Type             | message type name                      |
-     * | UserId           | creating user id                       |
-     * | AppId            | creating application id                |
-     * | ClusterID        | cluster ID                             |
-     *
-     * Default property:
-     * @sa setProperty
-     * @sa property
+     * Base class constructor.
+     * @detailed Construct frame class from received raw data.
+     * @param raw Data stream for reading source data.
      */
-    class QAMQP_EXPORT Content : public Base
-    {
-    public:
-        /*
-         * Content class constructor.
-         * @detailed Construct frame content header class for sending.
-         */
-        Content();
-
-        /*
-         * Content class constructor.
-         * @detailed Construct frame content header class for sending.
-         * @param methodClass Define method class id of constructed frame.
-         */
-        Content(MethodClass methodClass);
-
-        /*
-         * Content class constructor.
-         * @detailed Construct frame content header class for sending.
-         * @param raw Data stream for reading source data.
-         */
-        Content(QDataStream &raw);
-
-        /*
-         * Method class type.
-         */
-        MethodClass methodClass() const;
-        qint32 size() const;
-
-        /*
-         * Set default content header property
-         * @param prop Any default content header property
-         * @param value Associated data
-         */
-        void setProperty(Message::Property prop, const QVariant &value);
-
-        /*
-         * Return associated with property value
-         * @param prop Any default content header property
-         */
-        QVariant property(Message::Property prop) const;
-
-        qlonglong bodySize() const;
-        void setBodySize(qlonglong size);
-
-    protected:
-        void writePayload(QDataStream &stream) const;
-        void readPayload(QDataStream &stream);
-        short methodClass_;
-        qint16 id_;
-        mutable QByteArray buffer_;
-        Message::PropertyHash properties_;
-        qlonglong bodySize_;
-
-    private:
-        friend class QAMQP::QueuePrivate;
-
-    };
-
-    class QAMQP_EXPORT ContentBody : public Base
-    {
-    public:
-        ContentBody();
-        ContentBody(QDataStream &raw);
-
-        void setBody(const QByteArray &data);
-        QByteArray body() const;
-
-        qint32 size() const;
-    protected:
-        void writePayload(QDataStream &stream) const;
-        void readPayload(QDataStream &stream);
-
-    private:
-        QByteArray body_;
-    };
+    QAmqpFrame(QDataStream &raw);
 
     /*
-     * @brief Class for working with heartbeat frames.
-     * @detailed Implement frame for heartbeat send.
+     * Base class virtual destructor
      */
-    class QAMQP_EXPORT Heartbeat : public Base
-    {
-    public:
-        /*
-         * Heartbeat class constructor.
-         * @detailed Construct frame class for sending.
-         */
-        Heartbeat();
+    virtual ~QAmqpFrame();
 
-    protected:
-        void writePayload(QDataStream &stream) const;
-        void readPayload(QDataStream &stream);
-    };
+    /*
+     * Frame type
+     * @detailed Return type of current frame.
+     */
+    Type type() const;
 
-    class QAMQP_EXPORT MethodHandler
-    {
-    public:
-        virtual bool _q_method(const Frame::Method &frame) = 0;
-    };
+    /*
+     * Set number of associated channel.
+     * @param channel Number of channel.
+     * @sa channel()
+     */
+    void setChannel(qint16 channel);
 
-    class QAMQP_EXPORT ContentHandler
-    {
-    public:
-        virtual void _q_content(const Frame::Content &frame) = 0;
-    };
+    /*
+     * Return number of associated channel.
+     * @sa setChannel()
+     */
+    qint16 channel() const;
 
-    class QAMQP_EXPORT ContentBodyHandler
-    {
-    public:
-        virtual void _q_body(const Frame::ContentBody &frame) = 0;
-    };
+    /*
+     * Return size of frame.
+     */
+    virtual qint32 size() const;
 
-} // namespace Frame
+    /*
+     * Output frame to stream.
+     * @param stream Stream for serilize frame.
+     */
+    void toStream(QDataStream &stream) const;
 
-} // namespace QAMQP
+protected:
+    void writeHeader(QDataStream &stream) const;
+    virtual void writePayload(QDataStream &stream) const = 0;
+    void writeEnd(QDataStream &stream) const;
+
+    void readHeader(QDataStream &stream);
+    virtual void readPayload(QDataStream &stream) = 0;
+
+    qint32 size_;
+
+private:
+    qint8 type_;
+    qint16 channel_;
+
+};
+
+/*
+ * @brief Class for working with method frames.
+ * @detailed Implement main methods for serialize and deserialize raw method frame data.
+ * Method frame bodies consist of an invariant list of data fields, called "arguments". All method bodies start
+ * with identifier numbers for the class and method:
+ * @code Frame struct
+ * 0		   2		   4
+ * +----------+-----------+-------------- - -
+ * | class-id | method-id | arguments...
+ * +----------+-----------+-------------- - -
+ *     short	  short	...
+ * @endcode
+ */
+class QAMQP_EXPORT QAmqpMethodFrame : public QAmqpFrame
+{
+public:
+    /*
+     * Method class constructor.
+     * @detailed Construct frame class for sending.
+     * @param methodClass Define method class id of constructed frame.
+     * @param id Define method id of constructed frame.
+     */
+    explicit QAmqpMethodFrame(MethodClass methodClass, qint16 id);
+
+    /*
+     * Method class constructor.
+     * @detailed Construct frame class from received raw data.
+     * @param raw Data stream for reading source data.
+     */
+    explicit QAmqpMethodFrame(QDataStream &raw);
+
+    /*
+     * Method class type.
+     */
+    MethodClass methodClass() const;
+
+    /*
+     * Method id.
+     */
+    qint16 id() const;
+    qint32 size() const;
+
+    /*
+     * Set arguments for method.
+     * @param data Serialized method arguments.
+     * @sa arguments
+     */
+    void setArguments(const QByteArray &data);
+
+    /*
+     * Return arguments for method.
+     * @sa setArguments
+     */
+    QByteArray arguments() const;
+
+protected:
+    void writePayload(QDataStream &stream) const;
+    void readPayload(QDataStream &stream);
+    short methodClass_;
+    qint16 id_;
+    QByteArray arguments_;
+
+};
+
+/*
+ * @brief Class for working with content frames.
+ * @detailed Implement main methods for serialize and deserialize raw content frame data.
+ * A content header payload has this format:
+ * @code Frame struct
+ * +----------+--------+-----------+----------------+------------- - -
+ * | class-id | weight | body size | property flags | property list...
+ * +----------+--------+-----------+----------------+------------- - -
+ *     short     short   long long       short          remainder...
+ * @endcode
+ *
+ * | Property         | Description                            |
+ * | ---------------- | -------------------------------------- |
+ * | ContentType      | MIME content type                      |
+ * | ContentEncoding  | MIME content encoding                  |
+ * | Headers          | message header field table             |
+ * | DeliveryMode     | nonpersistent (1) or persistent (2)    |
+ * | Priority         | message priority, 0 to 9               |
+ * | CorrelationId    | application correlation identifier     |
+ * | ReplyTo          | address to reply to                    |
+ * | Expiration       | message expiration specification       |
+ * | MessageId        | application message identifier         |
+ * | Timestamp        | message timestamp                      |
+ * | Type             | message type name                      |
+ * | UserId           | creating user id                       |
+ * | AppId            | creating application id                |
+ * | ClusterID        | cluster ID                             |
+ *
+ * Default property:
+ * @sa setProperty
+ * @sa property
+ */
+class QAMQP_EXPORT QAmqpContentFrame : public QAmqpFrame
+{
+public:
+    /*
+     * Content class constructor.
+     * @detailed Construct frame content header class for sending.
+     */
+    QAmqpContentFrame();
+
+    /*
+     * Content class constructor.
+     * @detailed Construct frame content header class for sending.
+     * @param methodClass Define method class id of constructed frame.
+     */
+    QAmqpContentFrame(MethodClass methodClass);
+
+    /*
+     * Content class constructor.
+     * @detailed Construct frame content header class for sending.
+     * @param raw Data stream for reading source data.
+     */
+    QAmqpContentFrame(QDataStream &raw);
+
+    /*
+     * Method class type.
+     */
+    MethodClass methodClass() const;
+    qint32 size() const;
+
+    /*
+     * Set default content header property
+     * @param prop Any default content header property
+     * @param value Associated data
+     */
+    void setProperty(QAmqpMessage::Property prop, const QVariant &value);
+
+    /*
+     * Return associated with property value
+     * @param prop Any default content header property
+     */
+    QVariant property(QAmqpMessage::Property prop) const;
+
+    qlonglong bodySize() const;
+    void setBodySize(qlonglong size);
+
+protected:
+    void writePayload(QDataStream &stream) const;
+    void readPayload(QDataStream &stream);
+    short methodClass_;
+    qint16 id_;
+    mutable QByteArray buffer_;
+    QAmqpMessage::PropertyHash properties_;
+    qlonglong bodySize_;
+
+private:
+    friend class QAmqpQueuePrivate;
+
+};
+
+class QAMQP_EXPORT QAmqpContentBodyFrame : public QAmqpFrame
+{
+public:
+    QAmqpContentBodyFrame();
+    QAmqpContentBodyFrame(QDataStream &raw);
+
+    void setBody(const QByteArray &data);
+    QByteArray body() const;
+
+    qint32 size() const;
+protected:
+    void writePayload(QDataStream &stream) const;
+    void readPayload(QDataStream &stream);
+
+private:
+    QByteArray body_;
+};
+
+/*
+ * @brief Class for working with heartbeat frames.
+ * @detailed Implement frame for heartbeat send.
+ */
+class QAMQP_EXPORT QAmqpHeartbeatFrame : public QAmqpFrame
+{
+public:
+    /*
+     * Heartbeat class constructor.
+     * @detailed Construct frame class for sending.
+     */
+    QAmqpHeartbeatFrame();
+
+protected:
+    void writePayload(QDataStream &stream) const;
+    void readPayload(QDataStream &stream);
+};
+
+class QAMQP_EXPORT QAmqpMethodFrameHandler
+{
+public:
+    virtual bool _q_method(const QAmqpMethodFrame &frame) = 0;
+};
+
+class QAMQP_EXPORT QAmqpContentFrameHandler
+{
+public:
+    virtual void _q_content(const QAmqpContentFrame &frame) = 0;
+};
+
+class QAMQP_EXPORT QAmqpContentBodyFrameHandler
+{
+public:
+    virtual void _q_body(const QAmqpContentBodyFrame &frame) = 0;
+};
 
 #endif // QAMQPFRAME_P_H

--- a/src/qamqpglobal.h
+++ b/src/qamqpglobal.h
@@ -45,9 +45,7 @@
 
 #define qAmqpDebug if (qgetenv("QAMQP_DEBUG").isEmpty()); else qDebug
 
-namespace QAMQP {
-
-namespace MetaType {
+namespace QAmqpMetaType {
 
 enum ValueType
 {
@@ -77,7 +75,9 @@ enum ValueType
     Void
 };
 
-}   // namespace MetaType
+}   // namespace QAmqpMetaType
+
+namespace QAMQP {
 
 enum Error
 {

--- a/src/qamqpmessage.cpp
+++ b/src/qamqpmessage.cpp
@@ -2,9 +2,8 @@
 
 #include "qamqpmessage.h"
 #include "qamqpmessage_p.h"
-using namespace QAMQP;
 
-MessagePrivate::MessagePrivate()
+QAmqpMessagePrivate::QAmqpMessagePrivate()
     : deliveryTag(0),
       leftSize(0)
 {
@@ -12,27 +11,27 @@ MessagePrivate::MessagePrivate()
 
 //////////////////////////////////////////////////////////////////////////
 
-Message::Message()
-    : d(new MessagePrivate)
+QAmqpMessage::QAmqpMessage()
+    : d(new QAmqpMessagePrivate)
 {
 }
 
-Message::Message(const Message &other)
+QAmqpMessage::QAmqpMessage(const QAmqpMessage &other)
     : d(other.d)
 {
 }
 
-Message::~Message()
+QAmqpMessage::~QAmqpMessage()
 {
 }
 
-Message &Message::operator=(const Message &other)
+QAmqpMessage &QAmqpMessage::operator=(const QAmqpMessage &other)
 {
     d = other.d;
     return *this;
 }
 
-bool Message::operator==(const Message &message) const
+bool QAmqpMessage::operator==(const QAmqpMessage &message) const
 {
     if (message.d == d)
         return true;
@@ -47,76 +46,76 @@ bool Message::operator==(const Message &message) const
             message.d->leftSize == d->leftSize);
 }
 
-bool Message::isValid() const
+bool QAmqpMessage::isValid() const
 {
     return d->deliveryTag != 0 &&
            !d->exchangeName.isNull() &&
            !d->routingKey.isNull();
 }
 
-qlonglong Message::deliveryTag() const
+qlonglong QAmqpMessage::deliveryTag() const
 {
     return d->deliveryTag;
 }
 
-bool Message::isRedelivered() const
+bool QAmqpMessage::isRedelivered() const
 {
     return d->redelivered;
 }
 
-QString Message::exchangeName() const
+QString QAmqpMessage::exchangeName() const
 {
     return d->exchangeName;
 }
 
-QString Message::routingKey() const
+QString QAmqpMessage::routingKey() const
 {
     return d->routingKey;
 }
 
-QByteArray Message::payload() const
+QByteArray QAmqpMessage::payload() const
 {
     return d->payload;
 }
 
-bool Message::hasProperty(Property property) const
+bool QAmqpMessage::hasProperty(Property property) const
 {
     return d->properties.contains(property);
 }
 
-void Message::setProperty(Property property, const QVariant &value)
+void QAmqpMessage::setProperty(Property property, const QVariant &value)
 {
     d->properties.insert(property, value);
 }
 
-QVariant Message::property(Property property, const QVariant &defaultValue) const
+QVariant QAmqpMessage::property(Property property, const QVariant &defaultValue) const
 {
     return d->properties.value(property, defaultValue);
 }
 
-bool Message::hasHeader(const QString &header) const
+bool QAmqpMessage::hasHeader(const QString &header) const
 {
     return d->headers.contains(header);
 }
 
-void Message::setHeader(const QString &header, const QVariant &value)
+void QAmqpMessage::setHeader(const QString &header, const QVariant &value)
 {
     d->headers.insert(header, value);
 }
 
-QVariant Message::header(const QString &header, const QVariant &defaultValue) const
+QVariant QAmqpMessage::header(const QString &header, const QVariant &defaultValue) const
 {
     return d->headers.value(header, defaultValue);
 }
 
 #if QT_VERSION < 0x050000
-bool Message::isDetached() const
+bool QAmqpMessage::isDetached() const
 {
     return d && d->ref == 1;
 }
 #endif
 
-uint qHash(const QAMQP::Message &message, uint seed)
+uint qHash(const QAmqpMessage &message, uint seed)
 {
     Q_UNUSED(seed);
     return qHash(message.deliveryTag()) ^

--- a/src/qamqpmessage.h
+++ b/src/qamqpmessage.h
@@ -8,24 +8,21 @@
 
 #include "qamqpglobal.h"
 
-namespace QAMQP
-{
-
-class MessagePrivate;
-class QAMQP_EXPORT Message
+class QAmqpMessagePrivate;
+class QAMQP_EXPORT QAmqpMessage
 {
 public:
-    Message();
-    Message(const Message &other);
-    Message &operator=(const Message &other);
-    ~Message();
+    QAmqpMessage();
+    QAmqpMessage(const QAmqpMessage &other);
+    QAmqpMessage &operator=(const QAmqpMessage &other);
+    ~QAmqpMessage();
 
 #if QT_VERSION >= 0x050000
-    inline void swap(Message &other) { qSwap(d, other.d); }
+    inline void swap(QAmqpMessage &other) { qSwap(d, other.d); }
 #endif
 
-    bool operator==(const Message &message) const;
-    inline bool operator!=(const Message &message) const { return !(operator==(message)); }
+    bool operator==(const QAmqpMessage &message) const;
+    inline bool operator!=(const QAmqpMessage &message) const { return !(operator==(message)); }
 
     enum Property {
         ContentType = AMQP_BASIC_CONTENT_TYPE_FLAG,
@@ -62,13 +59,13 @@ public:
     QByteArray payload() const;
 
 private:
-    QSharedDataPointer<MessagePrivate> d;
-    friend class QueuePrivate;
-    friend class Queue;
+    QSharedDataPointer<QAmqpMessagePrivate> d;
+    friend class QAmqpQueuePrivate;
+    friend class QAmqpQueue;
 
 #if QT_VERSION < 0x050000
 public:
-    typedef QSharedDataPointer<MessagePrivate> DataPtr;
+    typedef QSharedDataPointer<QAmqpMessagePrivate> DataPtr;
     inline DataPtr &data_ptr() { return d; }
 
     // internal
@@ -76,16 +73,14 @@ public:
 #endif
 };
 
-} // namespace QAMQP
-
-Q_DECLARE_METATYPE(QAMQP::Message::PropertyHash)
+Q_DECLARE_METATYPE(QAmqpMessage::PropertyHash)
 
 #if QT_VERSION < 0x050000
-Q_DECLARE_TYPEINFO(QAMQP::Message, Q_MOVABLE_TYPE);
+Q_DECLARE_TYPEINFO(QAmqpMessage, Q_MOVABLE_TYPE);
 #endif
-Q_DECLARE_SHARED(QAMQP::Message)
+Q_DECLARE_SHARED(QAmqpMessage)
 
 // NOTE: needed only for MSVC support, don't depend on this hash
-QAMQP_EXPORT uint qHash(const QAMQP::Message &key, uint seed = 0);
+QAMQP_EXPORT uint qHash(const QAmqpMessage &key, uint seed = 0);
 
 #endif // QAMQPMESSAGE_H

--- a/src/qamqpmessage_p.h
+++ b/src/qamqpmessage_p.h
@@ -7,24 +7,20 @@
 #include "qamqpframe_p.h"
 #include "qamqpmessage.h"
 
-namespace QAMQP {
-
-class MessagePrivate : public QSharedData
+class QAmqpMessagePrivate : public QSharedData
 {
 public:
-    MessagePrivate();
+    QAmqpMessagePrivate();
 
     qlonglong deliveryTag;
     bool redelivered;
     QString exchangeName;
     QString routingKey;
     QByteArray payload;
-    QHash<Message::Property, QVariant> properties;
+    QHash<QAmqpMessage::Property, QVariant> properties;
     QHash<QString, QVariant> headers;
     int leftSize;
 
 };
-
-}   // namespace QAMQP
 
 #endif  // QAMQPMESSAGE_P_H

--- a/src/qamqpqueue.h
+++ b/src/qamqpqueue.h
@@ -7,14 +7,11 @@
 #include "qamqpmessage.h"
 #include "qamqpglobal.h"
 
-namespace QAMQP
-{
-
-class Client;
-class ClientPrivate;
-class Exchange;
-class QueuePrivate;
-class QAMQP_EXPORT Queue : public Channel, public QQueue<Message>
+class QAmqpClient;
+class QAmqpClientPrivate;
+class QAmqpExchange;
+class QAmqpQueuePrivate;
+class QAMQP_EXPORT QAmqpQueue : public QAmqpChannel, public QQueue<QAmqpMessage>
 {
     Q_OBJECT
     Q_ENUMS(QueueOptions)
@@ -52,7 +49,7 @@ public:
     };
     Q_DECLARE_FLAGS(RemoveOptions, RemoveOption)
 
-    ~Queue();
+    ~QAmqpQueue();
 
     bool isConsuming() const;
     void setConsumerTag(const QString &consumerTag);
@@ -61,16 +58,16 @@ public:
     // AMQP Queue
     void declare(int options = Durable|AutoDelete);
     void bind(const QString &exchangeName, const QString &key);
-    void bind(Exchange *exchange, const QString &key);
+    void bind(QAmqpExchange *exchange, const QString &key);
     void unbind(const QString &exchangeName, const QString &key);
-    void unbind(Exchange *exchange, const QString &key);
+    void unbind(QAmqpExchange *exchange, const QString &key);
     void purge();
     void remove(int options = roIfUnused|roIfEmpty|roNoWait);
 
     // AMQP Basic
     bool consume(int options = NoOptions);
     void get(bool noAck = true);
-    void ack(const Message &message);
+    void ack(const QAmqpMessage &message);
     bool cancel(bool noWait = false);
 
 Q_SIGNALS:
@@ -91,14 +88,12 @@ protected:
     virtual void channelClosed();
 
 private:
-    explicit Queue(int channelNumber = -1, Client *parent = 0);
+    explicit QAmqpQueue(int channelNumber = -1, QAmqpClient *parent = 0);
 
-    Q_DISABLE_COPY(Queue)
-    Q_DECLARE_PRIVATE(Queue)
+    Q_DISABLE_COPY(QAmqpQueue)
+    Q_DECLARE_PRIVATE(QAmqpQueue)
 
-    friend class Client;
+    friend class QAmqpClient;
 };
-
-} // namespace QAMQP
 
 #endif  // QAMQPQUEUE_H

--- a/src/qamqpqueue_p.h
+++ b/src/qamqpqueue_p.h
@@ -6,12 +6,9 @@
 
 #include "qamqpchannel_p.h"
 
-namespace QAMQP
-{
-
-class QueuePrivate: public ChannelPrivate,
-                    public Frame::ContentHandler,
-                    public Frame::ContentBodyHandler
+class QAmqpQueuePrivate: public QAmqpChannelPrivate,
+                         public QAmqpContentFrameHandler,
+                         public QAmqpContentBodyFrameHandler
 {
 public:
     enum MethodId {
@@ -22,26 +19,26 @@ public:
         METHOD_ID_ENUM(miDelete, 40)
     };
 
-    QueuePrivate(Queue *q);
-    ~QueuePrivate();
+    QAmqpQueuePrivate(QAmqpQueue *q);
+    ~QAmqpQueuePrivate();
 
     void declare();
-    virtual bool _q_method(const Frame::Method &frame);
+    virtual bool _q_method(const QAmqpMethodFrame &frame);
 
     // AMQP Queue method handlers
-    void declareOk(const Frame::Method &frame);
-    void deleteOk(const Frame::Method &frame);
-    void purgeOk(const Frame::Method &frame);
-    void bindOk(const Frame::Method &frame);
-    void unbindOk(const Frame::Method &frame);
-    void consumeOk(const Frame::Method &frame);
+    void declareOk(const QAmqpMethodFrame &frame);
+    void deleteOk(const QAmqpMethodFrame &frame);
+    void purgeOk(const QAmqpMethodFrame &frame);
+    void bindOk(const QAmqpMethodFrame &frame);
+    void unbindOk(const QAmqpMethodFrame &frame);
+    void consumeOk(const QAmqpMethodFrame &frame);
 
     // AMQP Basic method handlers
-    virtual void _q_content(const Frame::Content &frame);
-    virtual void _q_body(const Frame::ContentBody &frame);
-    void deliver(const Frame::Method &frame);
-    void getOk(const Frame::Method &frame);
-    void cancelOk(const Frame::Method &frame);
+    virtual void _q_content(const QAmqpContentFrame &frame);
+    virtual void _q_body(const QAmqpContentBodyFrame &frame);
+    void deliver(const QAmqpMethodFrame &frame);
+    void getOk(const QAmqpMethodFrame &frame);
+    void cancelOk(const QAmqpMethodFrame &frame);
 
     QString type;
     int options;
@@ -51,13 +48,11 @@ public:
 
     QString consumerTag;
     bool recievingMessage;
-    Message currentMessage;
+    QAmqpMessage currentMessage;
     bool consuming;
 
-    Q_DECLARE_PUBLIC(Queue)
+    Q_DECLARE_PUBLIC(QAmqpQueue)
 
 };
-
-} // namespace QAMQP
 
 #endif // QAMQPQUEUE_P_H

--- a/src/qamqptable.cpp
+++ b/src/qamqptable.cpp
@@ -5,7 +5,6 @@
 
 #include "qamqpframe_p.h"
 #include "qamqptable.h"
-using namespace QAMQP;
 
 /*
  * field value types according to: https://www.rabbitmq.com/amqp-0-9-1-errata.html
@@ -29,47 +28,47 @@ V - Void
 x - Byte array
 */
 
-MetaType::ValueType valueTypeForOctet(qint8 octet)
+QAmqpMetaType::ValueType valueTypeForOctet(qint8 octet)
 {
     switch (octet) {
-    case 't': return MetaType::Boolean;
-    case 'b': return MetaType::ShortShortInt;
-    case 's': return MetaType::ShortInt;
-    case 'I': return MetaType::LongInt;
-    case 'l': return MetaType::LongLongInt;
-    case 'f': return MetaType::Float;
-    case 'd': return MetaType::Double;
-    case 'D': return MetaType::Decimal;
-    case 'S': return MetaType::LongString;
-    case 'A': return MetaType::Array;
-    case 'T': return MetaType::Timestamp;
-    case 'F': return MetaType::Hash;
-    case 'V': return MetaType::Void;
-    case 'x': return MetaType::Bytes;
+    case 't': return QAmqpMetaType::Boolean;
+    case 'b': return QAmqpMetaType::ShortShortInt;
+    case 's': return QAmqpMetaType::ShortInt;
+    case 'I': return QAmqpMetaType::LongInt;
+    case 'l': return QAmqpMetaType::LongLongInt;
+    case 'f': return QAmqpMetaType::Float;
+    case 'd': return QAmqpMetaType::Double;
+    case 'D': return QAmqpMetaType::Decimal;
+    case 'S': return QAmqpMetaType::LongString;
+    case 'A': return QAmqpMetaType::Array;
+    case 'T': return QAmqpMetaType::Timestamp;
+    case 'F': return QAmqpMetaType::Hash;
+    case 'V': return QAmqpMetaType::Void;
+    case 'x': return QAmqpMetaType::Bytes;
     default:
         qAmqpDebug() << Q_FUNC_INFO << "invalid octet received: " << char(octet);
     }
 
-    return MetaType::Invalid;
+    return QAmqpMetaType::Invalid;
 }
 
-qint8 valueTypeToOctet(MetaType::ValueType type)
+qint8 valueTypeToOctet(QAmqpMetaType::ValueType type)
 {
     switch (type) {
-    case MetaType::Boolean: return 't';
-    case MetaType::ShortShortInt: return 'b';
-    case MetaType::ShortInt: return 's';
-    case MetaType::LongInt: return 'I';
-    case MetaType::LongLongInt: return 'l';
-    case MetaType::Float: return 'f';
-    case MetaType::Double: return 'd';
-    case MetaType::Decimal: return 'D';
-    case MetaType::LongString: return 'S';
-    case MetaType::Array: return 'A';
-    case MetaType::Timestamp: return 'T';
-    case MetaType::Hash: return 'F';
-    case MetaType::Void: return 'V';
-    case MetaType::Bytes: return 'x';
+    case QAmqpMetaType::Boolean: return 't';
+    case QAmqpMetaType::ShortShortInt: return 'b';
+    case QAmqpMetaType::ShortInt: return 's';
+    case QAmqpMetaType::LongInt: return 'I';
+    case QAmqpMetaType::LongLongInt: return 'l';
+    case QAmqpMetaType::Float: return 'f';
+    case QAmqpMetaType::Double: return 'd';
+    case QAmqpMetaType::Decimal: return 'D';
+    case QAmqpMetaType::LongString: return 'S';
+    case QAmqpMetaType::Array: return 'A';
+    case QAmqpMetaType::Timestamp: return 'T';
+    case QAmqpMetaType::Hash: return 'F';
+    case QAmqpMetaType::Void: return 'V';
+    case QAmqpMetaType::Bytes: return 'x';
     default:
         qAmqpDebug() << Q_FUNC_INFO << "invalid type received: " << char(type);
     }
@@ -77,71 +76,71 @@ qint8 valueTypeToOctet(MetaType::ValueType type)
     return 'V';
 }
 
-void Table::writeFieldValue(QDataStream &stream, const QVariant &value)
+void QAmqpTable::writeFieldValue(QDataStream &stream, const QVariant &value)
 {
-    MetaType::ValueType type;
+    QAmqpMetaType::ValueType type;
     switch (value.userType()) {
     case QMetaType::Bool:
-        type = MetaType::Boolean;
+        type = QAmqpMetaType::Boolean;
         break;
     case QMetaType::QByteArray:
-        type = MetaType::Bytes;
+        type = QAmqpMetaType::Bytes;
         break;
     case QMetaType::Int:
     {
         int i = qAbs(value.toInt());
         if (i <= qint8(SCHAR_MAX)) {
-            type = MetaType::ShortShortInt;
+            type = QAmqpMetaType::ShortShortInt;
         } else if (i <= qint16(SHRT_MAX)) {
-            type = MetaType::ShortInt;
+            type = QAmqpMetaType::ShortInt;
         } else {
-            type = MetaType::LongInt;
+            type = QAmqpMetaType::LongInt;
         }
     }
         break;
     case QMetaType::UShort:
-        type = MetaType::ShortInt;
+        type = QAmqpMetaType::ShortInt;
         break;
     case QMetaType::UInt:
     {
         int i = value.toInt();
         if (i <= qint8(SCHAR_MAX)) {
-            type = MetaType::ShortShortInt;
+            type = QAmqpMetaType::ShortShortInt;
         } else if (i <= qint16(SHRT_MAX)) {
-            type = MetaType::ShortInt;
+            type = QAmqpMetaType::ShortInt;
         } else {
-            type = MetaType::LongInt;
+            type = QAmqpMetaType::LongInt;
         }
     }
         break;
     case QMetaType::LongLong:
     case QMetaType::ULongLong:
-        type = MetaType::LongLongInt;
+        type = QAmqpMetaType::LongLongInt;
         break;
     case QMetaType::QString:
-        type = MetaType::LongString;
+        type = QAmqpMetaType::LongString;
         break;
     case QMetaType::QDateTime:
-        type = MetaType::Timestamp;
+        type = QAmqpMetaType::Timestamp;
         break;
     case QMetaType::Double:
-        type = value.toDouble() > FLT_MAX ? MetaType::Double : MetaType::Float;
+        type = value.toDouble() > FLT_MAX ? QAmqpMetaType::Double : QAmqpMetaType::Float;
         break;
     case QMetaType::QVariantHash:
-        type = MetaType::Hash;
+        type = QAmqpMetaType::Hash;
         break;
     case QMetaType::QVariantList:
-        type = MetaType::Array;
+        type = QAmqpMetaType::Array;
         break;
     case QMetaType::Void:
-        type = MetaType::Void;
+        type = QAmqpMetaType::Void;
         break;
     default:
         if (value.userType() == qMetaTypeId<QAMQP::Decimal>()) {
-            type = MetaType::Decimal;
+            type = QAmqpMetaType::Decimal;
             break;
         } else if (!value.isValid()) {
-            type = MetaType::Void;
+            type = QAmqpMetaType::Void;
             break;
         }
 
@@ -154,33 +153,33 @@ void Table::writeFieldValue(QDataStream &stream, const QVariant &value)
     writeFieldValue(stream, type, value);
 }
 
-void Table::writeFieldValue(QDataStream &stream, MetaType::ValueType type, const QVariant &value)
+void QAmqpTable::writeFieldValue(QDataStream &stream, QAmqpMetaType::ValueType type, const QVariant &value)
 {
     switch (type) {
-    case MetaType::Boolean:
-    case MetaType::ShortShortUint:
-    case MetaType::ShortUint:
-    case MetaType::LongUint:
-    case MetaType::LongLongUint:
-    case MetaType::ShortString:
-    case MetaType::LongString:
-    case MetaType::Timestamp:
-    case MetaType::Hash:
-        return Frame::writeAmqpField(stream, type, value);
+    case QAmqpMetaType::Boolean:
+    case QAmqpMetaType::ShortShortUint:
+    case QAmqpMetaType::ShortUint:
+    case QAmqpMetaType::LongUint:
+    case QAmqpMetaType::LongLongUint:
+    case QAmqpMetaType::ShortString:
+    case QAmqpMetaType::LongString:
+    case QAmqpMetaType::Timestamp:
+    case QAmqpMetaType::Hash:
+        return QAmqpFrame::writeAmqpField(stream, type, value);
 
-    case MetaType::ShortShortInt:
+    case QAmqpMetaType::ShortShortInt:
         stream << qint8(value.toInt());
         break;
-    case MetaType::ShortInt:
+    case QAmqpMetaType::ShortInt:
         stream << qint16(value.toInt());
         break;
-    case MetaType::LongInt:
+    case QAmqpMetaType::LongInt:
         stream << qint32(value.toInt());
         break;
-    case MetaType::LongLongInt:
+    case QAmqpMetaType::LongLongInt:
         stream << qlonglong(value.toLongLong());
         break;
-    case MetaType::Float:
+    case QAmqpMetaType::Float:
     {
         float g = value.toFloat();
         QDataStream::FloatingPointPrecision oldPrecision = stream.floatingPointPrecision();
@@ -189,7 +188,7 @@ void Table::writeFieldValue(QDataStream &stream, MetaType::ValueType type, const
         stream.setFloatingPointPrecision(oldPrecision);
     }
         break;
-    case MetaType::Double:
+    case QAmqpMetaType::Double:
     {
         double g = value.toDouble();
         QDataStream::FloatingPointPrecision oldPrecision = stream.floatingPointPrecision();
@@ -198,14 +197,14 @@ void Table::writeFieldValue(QDataStream &stream, MetaType::ValueType type, const
         stream.setFloatingPointPrecision(oldPrecision);
     }
         break;
-    case MetaType::Decimal:
+    case QAmqpMetaType::Decimal:
     {
         QAMQP::Decimal v(value.value<QAMQP::Decimal>());
         stream << v.scale;
         stream << v.value;
     }
         break;
-    case MetaType::Array:
+    case QAmqpMetaType::Array:
     {
         QByteArray buffer;
         QDataStream arrayStream(&buffer, QIODevice::WriteOnly);
@@ -220,14 +219,14 @@ void Table::writeFieldValue(QDataStream &stream, MetaType::ValueType type, const
         }
     }
         break;
-    case MetaType::Bytes:
+    case QAmqpMetaType::Bytes:
     {
         QByteArray ba = value.toByteArray();
         stream << quint32(ba.length());
         stream.writeRawData(ba.data(), ba.length());
     }
         break;
-    case MetaType::Void:
+    case QAmqpMetaType::Void:
         stream << qint32(0);
         break;
 
@@ -236,45 +235,45 @@ void Table::writeFieldValue(QDataStream &stream, MetaType::ValueType type, const
     }
 }
 
-QVariant Table::readFieldValue(QDataStream &stream, MetaType::ValueType type)
+QVariant QAmqpTable::readFieldValue(QDataStream &stream, QAmqpMetaType::ValueType type)
 {
     switch (type) {
-    case MetaType::Boolean:
-    case MetaType::ShortShortUint:
-    case MetaType::ShortUint:
-    case MetaType::LongUint:
-    case MetaType::LongLongUint:
-    case MetaType::ShortString:
-    case MetaType::LongString:
-    case MetaType::Timestamp:
-    case MetaType::Hash:
-        return Frame::readAmqpField(stream, type);
+    case QAmqpMetaType::Boolean:
+    case QAmqpMetaType::ShortShortUint:
+    case QAmqpMetaType::ShortUint:
+    case QAmqpMetaType::LongUint:
+    case QAmqpMetaType::LongLongUint:
+    case QAmqpMetaType::ShortString:
+    case QAmqpMetaType::LongString:
+    case QAmqpMetaType::Timestamp:
+    case QAmqpMetaType::Hash:
+        return QAmqpFrame::readAmqpField(stream, type);
 
-    case MetaType::ShortShortInt:
+    case QAmqpMetaType::ShortShortInt:
     {
         char octet;
         stream.readRawData(&octet, sizeof(octet));
         return QVariant::fromValue<int>(octet);
     }
-    case MetaType::ShortInt:
+    case QAmqpMetaType::ShortInt:
     {
         qint16 tmp_value = 0;
         stream >> tmp_value;
         return QVariant::fromValue<int>(tmp_value);
     }
-    case MetaType::LongInt:
+    case QAmqpMetaType::LongInt:
     {
         qint32 tmp_value = 0;
         stream >> tmp_value;
         return QVariant::fromValue<int>(tmp_value);
     }
-    case MetaType::LongLongInt:
+    case QAmqpMetaType::LongLongInt:
     {
         qlonglong v = 0 ;
         stream >> v;
         return v;
     }
-    case MetaType::Float:
+    case QAmqpMetaType::Float:
     {
         float tmp_value;
         QDataStream::FloatingPointPrecision precision = stream.floatingPointPrecision();
@@ -283,7 +282,7 @@ QVariant Table::readFieldValue(QDataStream &stream, MetaType::ValueType type)
         stream.setFloatingPointPrecision(precision);
         return QVariant::fromValue<float>(tmp_value);
     }
-    case MetaType::Double:
+    case QAmqpMetaType::Double:
     {
         double tmp_value;
         QDataStream::FloatingPointPrecision precision = stream.floatingPointPrecision();
@@ -292,14 +291,14 @@ QVariant Table::readFieldValue(QDataStream &stream, MetaType::ValueType type)
         stream.setFloatingPointPrecision(precision);
         return QVariant::fromValue<double>(tmp_value);
     }
-    case MetaType::Decimal:
+    case QAmqpMetaType::Decimal:
     {
         QAMQP::Decimal v;
         stream >> v.scale;
         stream >> v.value;
         return QVariant::fromValue<QAMQP::Decimal>(v);
     }
-    case MetaType::Array:
+    case QAmqpMetaType::Array:
     {
         QByteArray data;
         quint32 size = 0;
@@ -317,7 +316,7 @@ QVariant Table::readFieldValue(QDataStream &stream, MetaType::ValueType type)
 
         return result;
     }
-    case MetaType::Bytes:
+    case QAmqpMetaType::Bytes:
     {
         QByteArray bytes;
         quint32 length = 0;
@@ -326,7 +325,7 @@ QVariant Table::readFieldValue(QDataStream &stream, MetaType::ValueType type)
         stream.readRawData(bytes.data(), bytes.size());
         return bytes;
     }
-    case MetaType::Void:
+    case QAmqpMetaType::Void:
         break;
     default:
         qAmqpDebug() << Q_FUNC_INFO << "unhandled type: " << type;
@@ -335,15 +334,15 @@ QVariant Table::readFieldValue(QDataStream &stream, MetaType::ValueType type)
     return QVariant();
 }
 
-QDataStream &operator<<(QDataStream &stream, const Table &table)
+QDataStream &operator<<(QDataStream &stream, const QAmqpTable &table)
 {
     QByteArray data;
     QDataStream s(&data, QIODevice::WriteOnly);
-    Table::ConstIterator it;
-    Table::ConstIterator itEnd = table.constEnd();
+    QAmqpTable::ConstIterator it;
+    QAmqpTable::ConstIterator itEnd = table.constEnd();
     for (it = table.constBegin(); it != itEnd; ++it) {
-        Table::writeFieldValue(s, MetaType::ShortString, it.key());
-        Table::writeFieldValue(s, it.value());
+        QAmqpTable::writeFieldValue(s, QAmqpMetaType::ShortString, it.key());
+        QAmqpTable::writeFieldValue(s, it.value());
     }
 
     if (data.isEmpty()) {
@@ -355,16 +354,16 @@ QDataStream &operator<<(QDataStream &stream, const Table &table)
     return stream;
 }
 
-QDataStream &operator>>(QDataStream &stream, Table &table)
+QDataStream &operator>>(QDataStream &stream, QAmqpTable &table)
 {
     QByteArray data;
     stream >> data;
     QDataStream tableStream(&data, QIODevice::ReadOnly);
     while (!tableStream.atEnd()) {
         qint8 octet = 0;
-        QString field = Frame::readAmqpField(tableStream, MetaType::ShortString).toString();
+        QString field = QAmqpFrame::readAmqpField(tableStream, QAmqpMetaType::ShortString).toString();
         tableStream >> octet;
-        table[field] = Table::readFieldValue(tableStream, valueTypeForOctet(octet));
+        table[field] = QAmqpTable::readFieldValue(tableStream, valueTypeForOctet(octet));
     }
 
     return stream;

--- a/src/qamqptable.h
+++ b/src/qamqptable.h
@@ -5,26 +5,22 @@
 
 #include "qamqpglobal.h"
 
-namespace QAMQP {
-
-class QAMQP_EXPORT Table : public QVariantHash
+class QAMQP_EXPORT QAmqpTable : public QVariantHash
 {
 public:
-    Table() {}
-    inline Table(const QVariantHash &variantHash)
+    QAmqpTable() {}
+    inline QAmqpTable(const QVariantHash &variantHash)
         : QVariantHash(variantHash)
     {
     }
 
     static void writeFieldValue(QDataStream &stream, const QVariant &value);
-    static void writeFieldValue(QDataStream &stream, MetaType::ValueType type, const QVariant &value);
-    static QVariant readFieldValue(QDataStream &stream, MetaType::ValueType type);
+    static void writeFieldValue(QDataStream &stream, QAmqpMetaType::ValueType type, const QVariant &value);
+    static QVariant readFieldValue(QDataStream &stream, QAmqpMetaType::ValueType type);
 };
 
-}   // namespace QAMQP
-
-QAMQP_EXPORT QDataStream &operator<<(QDataStream &, const QAMQP::Table &table);
-QAMQP_EXPORT QDataStream &operator>>(QDataStream &, QAMQP::Table &table);
-Q_DECLARE_METATYPE(QAMQP::Table)
+QAMQP_EXPORT QDataStream &operator<<(QDataStream &, const QAmqpTable &table);
+QAMQP_EXPORT QDataStream &operator>>(QDataStream &, QAmqpTable &table);
+Q_DECLARE_METATYPE(QAmqpTable)
 
 #endif  // QAMQPTABLE_H

--- a/tests/auto/qamqpclient/tst_qamqpclient.cpp
+++ b/tests/auto/qamqpclient/tst_qamqpclient.cpp
@@ -6,7 +6,6 @@
 #include "qamqpclient_p.h"
 #include "qamqpauthenticator.h"
 
-using namespace QAMQP;
 class tst_QAMQPClient : public TestCase
 {
     Q_OBJECT
@@ -28,7 +27,7 @@ private:
 
 void tst_QAMQPClient::connect()
 {
-    Client client;
+    QAmqpClient client;
     client.connectToHost();
     QVERIFY(waitForSignal(&client, SIGNAL(connected())));
 
@@ -45,7 +44,7 @@ void tst_QAMQPClient::connect()
 
 void tst_QAMQPClient::connectProperties()
 {
-    Client client;
+    QAmqpClient client;
     client.setHost("localhost");
     client.setPort(5672);
     client.setVirtualHost("/");
@@ -60,7 +59,7 @@ void tst_QAMQPClient::connectProperties()
 
 void tst_QAMQPClient::connectHostAddress()
 {
-    Client client;
+    QAmqpClient client;
     client.connectToHost(QHostAddress::LocalHost, 5672);
     QVERIFY(waitForSignal(&client, SIGNAL(connected())));
     client.disconnectFromHost();
@@ -69,14 +68,14 @@ void tst_QAMQPClient::connectHostAddress()
 
 void tst_QAMQPClient::connectDisconnect()
 {
-    Client client;
+    QAmqpClient client;
     client.connectToHost();
     QVERIFY(waitForSignal(&client, SIGNAL(connected())));
     client.disconnectFromHost();
     QVERIFY(waitForSignal(&client, SIGNAL(disconnected())));
 }
 
-class InvalidAuthenticator : public Authenticator
+class InvalidAuthenticator : public QAmqpAuthenticator
 {
 public:
     virtual QString type() const { return "CRAZYAUTH"; }
@@ -87,7 +86,7 @@ public:
 
 void tst_QAMQPClient::invalidAuthenticationMechanism()
 {
-    Client client;
+    QAmqpClient client;
     client.setAuth(new InvalidAuthenticator);
     client.connectToHost();
     QVERIFY(waitForSignal(&client, SIGNAL(disconnected())));
@@ -98,7 +97,7 @@ void tst_QAMQPClient::autoReconnect()
     // TODO: this is a fairly crude way of testing this, research
     //       better alternatives
 
-    Client client;
+    QAmqpClient client;
     client.setAutoReconnect(true);
     client.connectToHost();
     QVERIFY(waitForSignal(&client, SIGNAL(connected())));
@@ -110,7 +109,7 @@ void tst_QAMQPClient::autoReconnect()
 
 void tst_QAMQPClient::tune()
 {
-    Client client;
+    QAmqpClient client;
     client.setChannelMax(15);
     client.setFrameMax(5000);
     client.setHeartbeatDelay(600);
@@ -163,15 +162,15 @@ void tst_QAMQPClient::validateUri()
     QFETCH(quint16, expectedPort);
     QFETCH(QString, expectedVirtualHost);
 
-    ClientPrivate clientPrivate(0);
+    QAmqpClientPrivate clientPrivate(0);
     // fake init
-    clientPrivate.authenticator = QSharedPointer<Authenticator>(
-        new AMQPlainAuthenticator(QString::fromLatin1(AMQP_LOGIN), QString::fromLatin1(AMQP_PSWD)));
+    clientPrivate.authenticator = QSharedPointer<QAmqpAuthenticator>(
+        new QAmqpPlainAuthenticator(QString::fromLatin1(AMQP_LOGIN), QString::fromLatin1(AMQP_PSWD)));
 
     // test parsing
     clientPrivate.parseConnectionString(uri);
-    AMQPlainAuthenticator *auth =
-        static_cast<AMQPlainAuthenticator*>(clientPrivate.authenticator.data());
+    QAmqpPlainAuthenticator *auth =
+        static_cast<QAmqpPlainAuthenticator*>(clientPrivate.authenticator.data());
 
     QCOMPARE(auth->login(), expectedUsername);
     QCOMPARE(auth->password(), expectedPassword);

--- a/tests/common/qamqptestcase.h
+++ b/tests/common/qamqptestcase.h
@@ -6,8 +6,6 @@
 
 #include "qamqpqueue.h"
 
-namespace QAMQP {
-
 class TestCase : public QObject
 {
 public:
@@ -26,7 +24,7 @@ protected:
         return !QTestEventLoop::instance().timeout();
     }
 
-    void declareQueueAndVerifyConsuming(Queue *queue)
+    void declareQueueAndVerifyConsuming(QAmqpQueue *queue)
     {
         queue->declare();
         QVERIFY(waitForSignal(queue, SIGNAL(declared())));
@@ -39,7 +37,7 @@ protected:
         QCOMPARE(arguments.at(0).toString(), queue->consumerTag());
     }
 
-    void verifyStandardMessageHeaders(const Message &message, const QString &routingKey,
+    void verifyStandardMessageHeaders(const QAmqpMessage &message, const QString &routingKey,
                                       const QString &exchangeName = QLatin1String(""),
                                       bool redelivered = false)
     {
@@ -47,9 +45,6 @@ protected:
         QCOMPARE(message.exchangeName(), exchangeName);
         QCOMPARE(message.isRedelivered(), redelivered);
     }
-
 };
-
-}   // namespace QAMQP
 
 #endif  // QAMQPTESTCASE_H

--- a/tutorials/helloworld/receive/main.cpp
+++ b/tutorials/helloworld/receive/main.cpp
@@ -4,7 +4,6 @@
 #include "qamqpclient.h"
 #include "qamqpexchange.h"
 #include "qamqpqueue.h"
-using namespace QAMQP;
 
 class Receiver : public QObject
 {
@@ -20,32 +19,32 @@ public Q_SLOTS:
 
 private Q_SLOTS:
     void clientConnected() {
-        Queue *queue = m_client.createQueue("hello");
+        QAmqpQueue *queue = m_client.createQueue("hello");
         connect(queue, SIGNAL(declared()), this, SLOT(queueDeclared()));
         queue->declare();
     }
 
     void queueDeclared() {
-        Queue *queue = qobject_cast<Queue*>(sender());
+        QAmqpQueue *queue = qobject_cast<QAmqpQueue*>(sender());
         if (!queue)
             return;
 
         connect(queue, SIGNAL(messageReceived()), this, SLOT(messageReceived()));
-        queue->consume(Queue::coNoAck);
+        queue->consume(QAmqpQueue::coNoAck);
         qDebug() << " [*] Waiting for messages. To exit press CTRL+C";
     }
 
     void messageReceived() {
-        Queue *queue = qobject_cast<Queue*>(sender());
+        QAmqpQueue *queue = qobject_cast<QAmqpQueue*>(sender());
         if (!queue)
             return;
 
-        Message message = queue->dequeue();
+        QAmqpMessage message = queue->dequeue();
         qDebug() << " [x] Received " << message.payload();
     }
 
 private:
-    Client m_client;
+    QAmqpClient m_client;
 
 };
 

--- a/tutorials/helloworld/send/main.cpp
+++ b/tutorials/helloworld/send/main.cpp
@@ -5,7 +5,6 @@
 #include "qamqpclient.h"
 #include "qamqpexchange.h"
 #include "qamqpqueue.h"
-using namespace QAMQP;
 
 class Sender : public QObject
 {
@@ -22,23 +21,23 @@ public Q_SLOTS:
 
 private Q_SLOTS:
     void clientConnected() {
-        Queue *queue = m_client.createQueue("hello");
+        QAmqpQueue *queue = m_client.createQueue("hello");
         connect(queue, SIGNAL(declared()), this, SLOT(queueDeclared()));
         queue->declare();
     }
 
     void queueDeclared() {
-        Queue *queue = qobject_cast<Queue*>(sender());
+        QAmqpQueue *queue = qobject_cast<QAmqpQueue*>(sender());
         if (!queue)
             return;
-        Exchange *defaultExchange = m_client.createExchange();
+        QAmqpExchange *defaultExchange = m_client.createExchange();
         defaultExchange->publish("Hello World!", "hello");
         qDebug() << " [x] Sent 'Hello World!'";
         m_client.disconnectFromHost();
     }
 
 private:
-    Client m_client;
+    QAmqpClient m_client;
 
 };
 

--- a/tutorials/pubsub/emit_log/main.cpp
+++ b/tutorials/pubsub/emit_log/main.cpp
@@ -5,7 +5,6 @@
 #include "qamqpclient.h"
 #include "qamqpexchange.h"
 #include "qamqpqueue.h"
-using namespace QAMQP;
 
 class LogEmitter : public QObject
 {
@@ -22,13 +21,13 @@ public Q_SLOTS:
 
 private Q_SLOTS:
     void clientConnected() {
-        Exchange *exchange = m_client.createExchange("logs");
+        QAmqpExchange *exchange = m_client.createExchange("logs");
         connect(exchange, SIGNAL(declared()), this, SLOT(exchangeDeclared()));
-        exchange->declare(Exchange::FanOut);
+        exchange->declare(QAmqpExchange::FanOut);
     }
 
     void exchangeDeclared() {
-        Exchange *exchange = qobject_cast<Exchange*>(sender());
+        QAmqpExchange *exchange = qobject_cast<QAmqpExchange*>(sender());
         if (!exchange)
             return;
 
@@ -43,7 +42,7 @@ private Q_SLOTS:
     }
 
 private:
-    Client m_client;
+    QAmqpClient m_client;
 
 };
 

--- a/tutorials/pubsub/receive_logs/main.cpp
+++ b/tutorials/pubsub/receive_logs/main.cpp
@@ -5,7 +5,6 @@
 #include "qamqpclient.h"
 #include "qamqpexchange.h"
 #include "qamqpqueue.h"
-using namespace QAMQP;
 
 class LogReceiver : public QObject
 {
@@ -21,21 +20,21 @@ public Q_SLOTS:
 
 private Q_SLOTS:
     void clientConnected() {
-        Exchange *exchange = m_client.createExchange("logs");
+        QAmqpExchange *exchange = m_client.createExchange("logs");
         connect(exchange, SIGNAL(declared()), this, SLOT(exchangeDeclared()));
-        exchange->declare(Exchange::FanOut);
+        exchange->declare(QAmqpExchange::FanOut);
     }
 
     void exchangeDeclared() {
-        Queue *temporaryQueue = m_client.createQueue();
+        QAmqpQueue *temporaryQueue = m_client.createQueue();
         connect(temporaryQueue, SIGNAL(declared()), this, SLOT(queueDeclared()));
         connect(temporaryQueue, SIGNAL(bound()), this, SLOT(queueBound()));
         connect(temporaryQueue, SIGNAL(messageReceived()), this, SLOT(messageReceived()));
-        temporaryQueue->declare(Queue::Exclusive);
+        temporaryQueue->declare(QAmqpQueue::Exclusive);
     }
 
     void queueDeclared() {
-        Queue *temporaryQueue = qobject_cast<Queue*>(sender());
+        QAmqpQueue *temporaryQueue = qobject_cast<QAmqpQueue*>(sender());
         if (!temporaryQueue)
             return;
 
@@ -43,25 +42,25 @@ private Q_SLOTS:
     }
 
     void queueBound() {
-        Queue *temporaryQueue = qobject_cast<Queue*>(sender());
+        QAmqpQueue *temporaryQueue = qobject_cast<QAmqpQueue*>(sender());
         if (!temporaryQueue)
             return;
 
         qDebug() << " [*] Waiting for logs. To exit press CTRL+C";
-        temporaryQueue->consume(Queue::coNoAck);
+        temporaryQueue->consume(QAmqpQueue::coNoAck);
     }
 
     void messageReceived() {
-        Queue *temporaryQueue = qobject_cast<Queue*>(sender());
+        QAmqpQueue *temporaryQueue = qobject_cast<QAmqpQueue*>(sender());
         if (!temporaryQueue)
             return;
 
-        Message message = temporaryQueue->dequeue();
+        QAmqpMessage message = temporaryQueue->dequeue();
         qDebug() << " [x] " << message.payload();
     }
 
 private:
-    Client m_client;
+    QAmqpClient m_client;
 
 };
 

--- a/tutorials/routing/emit_log_direct/main.cpp
+++ b/tutorials/routing/emit_log_direct/main.cpp
@@ -5,7 +5,6 @@
 #include "qamqpclient.h"
 #include "qamqpexchange.h"
 #include "qamqpqueue.h"
-using namespace QAMQP;
 
 class DirectLogEmitter : public QObject
 {
@@ -22,13 +21,13 @@ public Q_SLOTS:
 
 private Q_SLOTS:
     void clientConnected() {
-        Exchange *direct_logs = m_client.createExchange("direct_logs");
+        QAmqpExchange *direct_logs = m_client.createExchange("direct_logs");
         connect(direct_logs, SIGNAL(declared()), this, SLOT(exchangeDeclared()));
-        direct_logs->declare(Exchange::Direct);
+        direct_logs->declare(QAmqpExchange::Direct);
     }
 
     void exchangeDeclared() {
-        Exchange *direct_logs = qobject_cast<Exchange*>(sender());
+        QAmqpExchange *direct_logs = qobject_cast<QAmqpExchange*>(sender());
         if (!direct_logs)
             return;
 
@@ -50,7 +49,7 @@ private Q_SLOTS:
     }
 
 private:
-    Client m_client;
+    QAmqpClient m_client;
 
 };
 

--- a/tutorials/routing/receive_logs_direct/main.cpp
+++ b/tutorials/routing/receive_logs_direct/main.cpp
@@ -5,7 +5,6 @@
 #include "qamqpclient.h"
 #include "qamqpexchange.h"
 #include "qamqpqueue.h"
-using namespace QAMQP;
 
 class DirectLogReceiver : public QObject
 {
@@ -22,25 +21,25 @@ public Q_SLOTS:
 
 private Q_SLOTS:
     void clientConnected() {
-        Exchange *exchange = m_client.createExchange("direct_logs");
+        QAmqpExchange *exchange = m_client.createExchange("direct_logs");
         connect(exchange, SIGNAL(declared()), this, SLOT(exchangeDeclared()));
-        exchange->declare(Exchange::Direct);
+        exchange->declare(QAmqpExchange::Direct);
     }
 
     void exchangeDeclared() {
-        Queue *temporaryQueue = m_client.createQueue();
+        QAmqpQueue *temporaryQueue = m_client.createQueue();
         connect(temporaryQueue, SIGNAL(declared()), this, SLOT(queueDeclared()));
         connect(temporaryQueue, SIGNAL(messageReceived()), this, SLOT(messageReceived()));
-        temporaryQueue->declare(Queue::Exclusive);
+        temporaryQueue->declare(QAmqpQueue::Exclusive);
     }
 
     void queueDeclared() {
-        Queue *temporaryQueue = qobject_cast<Queue*>(sender());
+        QAmqpQueue *temporaryQueue = qobject_cast<QAmqpQueue*>(sender());
         if (!temporaryQueue)
             return;
 
         // start consuming
-        temporaryQueue->consume(Queue::coNoAck);
+        temporaryQueue->consume(QAmqpQueue::coNoAck);
 
         foreach (QString severity, m_severities)
             temporaryQueue->bind("direct_logs", severity);
@@ -48,16 +47,16 @@ private Q_SLOTS:
     }
 
     void messageReceived() {
-        Queue *temporaryQueue = qobject_cast<Queue*>(sender());
+        QAmqpQueue *temporaryQueue = qobject_cast<QAmqpQueue*>(sender());
         if (!temporaryQueue)
             return;
 
-        Message message = temporaryQueue->dequeue();
+        QAmqpMessage message = temporaryQueue->dequeue();
         qDebug() << " [x] " << message.routingKey() << ":" << message.payload();
     }
 
 private:
-    Client m_client;
+    QAmqpClient m_client;
     QStringList m_severities;
 
 };

--- a/tutorials/topics/emit_log_topic/main.cpp
+++ b/tutorials/topics/emit_log_topic/main.cpp
@@ -5,7 +5,6 @@
 #include "qamqpclient.h"
 #include "qamqpexchange.h"
 #include "qamqpqueue.h"
-using namespace QAMQP;
 
 class TopicLogEmitter : public QObject
 {
@@ -22,13 +21,13 @@ public Q_SLOTS:
 
 private Q_SLOTS:
     void clientConnected() {
-        Exchange *topic_logs = m_client.createExchange("topic_logs");
+        QAmqpExchange *topic_logs = m_client.createExchange("topic_logs");
         connect(topic_logs, SIGNAL(declared()), this, SLOT(exchangeDeclared()));
-        topic_logs->declare(Exchange::Topic);
+        topic_logs->declare(QAmqpExchange::Topic);
     }
 
     void exchangeDeclared() {
-        Exchange *topic_logs = qobject_cast<Exchange*>(sender());
+        QAmqpExchange *topic_logs = qobject_cast<QAmqpExchange*>(sender());
         if (!topic_logs)
             return;
 
@@ -50,7 +49,7 @@ private Q_SLOTS:
     }
 
 private:
-    Client m_client;
+    QAmqpClient m_client;
 
 };
 

--- a/tutorials/topics/receive_logs_topic/main.cpp
+++ b/tutorials/topics/receive_logs_topic/main.cpp
@@ -5,7 +5,6 @@
 #include "qamqpclient.h"
 #include "qamqpexchange.h"
 #include "qamqpqueue.h"
-using namespace QAMQP;
 
 class TopicLogReceiver : public QObject
 {
@@ -22,21 +21,21 @@ public Q_SLOTS:
 
 private Q_SLOTS:
     void clientConnected() {
-        Exchange *topic_logs = m_client.createExchange("topic_logs");
+        QAmqpExchange *topic_logs = m_client.createExchange("topic_logs");
         connect(topic_logs, SIGNAL(declared()), this, SLOT(exchangeDeclared()));
-        topic_logs->declare(Exchange::Topic);
+        topic_logs->declare(QAmqpExchange::Topic);
     }
 
     void exchangeDeclared() {
-        Queue *temporaryQueue = m_client.createQueue();
+        QAmqpQueue *temporaryQueue = m_client.createQueue();
         connect(temporaryQueue, SIGNAL(declared()), this, SLOT(queueDeclared()));
         connect(temporaryQueue, SIGNAL(bound()), this, SLOT(queueBound()));
         connect(temporaryQueue, SIGNAL(messageReceived()), this, SLOT(messageReceived()));
-        temporaryQueue->declare(Queue::Exclusive);
+        temporaryQueue->declare(QAmqpQueue::Exclusive);
     }
 
     void queueDeclared() {
-        Queue *temporaryQueue = qobject_cast<Queue*>(sender());
+        QAmqpQueue *temporaryQueue = qobject_cast<QAmqpQueue*>(sender());
         if (!temporaryQueue)
             return;
 
@@ -46,23 +45,23 @@ private Q_SLOTS:
     }
 
     void queueBound() {
-        Queue *temporaryQueue = qobject_cast<Queue*>(sender());
+        QAmqpQueue *temporaryQueue = qobject_cast<QAmqpQueue*>(sender());
         if (!temporaryQueue)
             return;
-        temporaryQueue->consume(Queue::coNoAck);
+        temporaryQueue->consume(QAmqpQueue::coNoAck);
     }
 
     void messageReceived() {
-        Queue *temporaryQueue = qobject_cast<Queue*>(sender());
+        QAmqpQueue *temporaryQueue = qobject_cast<QAmqpQueue*>(sender());
         if (!temporaryQueue)
             return;
 
-        Message message = temporaryQueue->dequeue();
+        QAmqpMessage message = temporaryQueue->dequeue();
         qDebug() << " [x] " << message.routingKey() << ":" << message.payload();
     }
 
 private:
-    Client m_client;
+    QAmqpClient m_client;
     QStringList m_bindingKeys;
 
 };

--- a/tutorials/workqueues/new_task/main.cpp
+++ b/tutorials/workqueues/new_task/main.cpp
@@ -5,7 +5,6 @@
 #include "qamqpclient.h"
 #include "qamqpexchange.h"
 #include "qamqpqueue.h"
-using namespace QAMQP;
 
 class TaskCreator : public QObject
 {
@@ -22,19 +21,19 @@ public Q_SLOTS:
 
 private Q_SLOTS:
     void clientConnected() {
-        Queue *queue = m_client.createQueue("task_queue");
+        QAmqpQueue *queue = m_client.createQueue("task_queue");
         connect(queue, SIGNAL(declared()), this, SLOT(queueDeclared()));
         queue->declare();
     }
 
     void queueDeclared() {
-        Queue *queue = qobject_cast<Queue*>(sender());
+        QAmqpQueue *queue = qobject_cast<QAmqpQueue*>(sender());
         if (!queue)
             return;
 
-        Exchange *defaultExchange = m_client.createExchange();
-        Message::PropertyHash properties;
-        properties[Message::DeliveryMode] = "2";   // make message persistent
+        QAmqpExchange *defaultExchange = m_client.createExchange();
+        QAmqpMessage::PropertyHash properties;
+        properties[QAmqpMessage::DeliveryMode] = "2";   // make message persistent
 
         QString message;
         if (qApp->arguments().size() < 2)
@@ -48,7 +47,7 @@ private Q_SLOTS:
     }
 
 private:
-    Client m_client;
+    QAmqpClient m_client;
 
 };
 

--- a/tutorials/workqueues/worker/main.cpp
+++ b/tutorials/workqueues/worker/main.cpp
@@ -4,7 +4,6 @@
 
 #include "qamqpclient.h"
 #include "qamqpqueue.h"
-using namespace QAMQP;
 
 class Worker : public QObject
 {
@@ -46,9 +45,9 @@ private Q_SLOTS:
     }
 
 private:
-    Client m_client;
-    Queue *m_queue;
-    Message m_currentMessage;
+    QAmqpClient m_client;
+    QAmqpQueue *m_queue;
+    QAmqpMessage m_currentMessage;
 
 };
 


### PR DESCRIPTION
This is a very small library, so there is no real pressing need for
a library namespace. Further, the namespacing actually makes it rather
difficult to work with in some cases. Opting for a more "Qt" style
class naming scheme, using the QAmqp class prefix
