### PR TITLE
Fix problem of ms vs seconds for heartbeat

### DIFF
--- a/src/qamqpclient.cpp
+++ b/src/qamqpclient.cpp
@@ -504,7 +504,7 @@ void QAmqpClientPrivate::tuneOk()
 
     stream << qint16(channelMax);
     stream << qint32(frameMax);
-    stream << qint16(heartbeatDelay / 1000);
+    stream << qint16(heartbeatDelay);
 
     frame.setArguments(arguments);
     sendFrame(frame);


### PR DESCRIPTION
In the tune packet from the server, we receive 580s by default.
In the packet we return to the server, we also need to return seconds.
The only place where we need to adapt ms & s is when we set the interval on the QTimer. Everywhere else, we only use seconds. Even when affecting heartbeatDelay.