### PR TITLE
Fix issues with channelNumber's type and nextChannelNumber

### DIFF
--- a/src/qamqpchannel.cpp
+++ b/src/qamqpchannel.cpp
@@ -6,7 +6,7 @@
 #include "qamqpclient.h"
 #include "qamqpclient_p.h"
 
-int QAmqpChannelPrivate::nextChannelNumber = 0;
+quint16 QAmqpChannelPrivate::nextChannelNumber = 0;
 QAmqpChannelPrivate::QAmqpChannelPrivate(QAmqpChannel *q)
     : channelNumber(0),
       opened(false),

--- a/src/qamqpchannel.cpp
+++ b/src/qamqpchannel.cpp
@@ -33,7 +33,7 @@ void QAmqpChannelPrivate::init(int channel, QAmqpClient *c)
     client = c;
     needOpen = channel == -1 ? true : false;
     channelNumber = channel == -1 ? ++nextChannelNumber : channel;
-    nextChannelNumber = qMax(channelNumber, (nextChannelNumber + 1));
+    nextChannelNumber = qMax(channelNumber, nextChannelNumber);
 }
 
 bool QAmqpChannelPrivate::_q_method(const QAmqpMethodFrame &frame)

--- a/src/qamqpchannel_p.h
+++ b/src/qamqpchannel_p.h
@@ -60,8 +60,8 @@ public:
 
     QPointer<QAmqpClient> client;
     QString name;
-    int channelNumber;
-    static int nextChannelNumber;
+    quint16 channelNumber;
+    static quint16 nextChannelNumber;
     bool opened;
     bool needOpen;
 

--- a/src/qamqpframe.cpp
+++ b/src/qamqpframe.cpp
@@ -22,12 +22,12 @@ QAmqpFrame::~QAmqpFrame()
 {
 }
 
-void QAmqpFrame::setChannel(qint16 channel)
+void QAmqpFrame::setChannel(quint16 channel)
 {
     channel_ = channel;
 }
 
-qint16 QAmqpFrame::channel() const
+quint16 QAmqpFrame::channel() const
 {
     return channel_;
 }

--- a/src/qamqpframe_p.h
+++ b/src/qamqpframe_p.h
@@ -39,8 +39,8 @@ public:
 
     FrameType type() const;
 
-    qint16 channel() const;
-    void setChannel(qint16 channel);
+    quint16 channel() const;
+    void setChannel(quint16 channel);
 
     virtual qint32 size() const;
 
@@ -56,7 +56,7 @@ protected:
 
 private:
     qint8 type_;
-    qint16 channel_;
+    quint16 channel_;
 
     friend QDataStream &operator<<(QDataStream &stream, const QAmqpFrame &frame);
     friend QDataStream &operator>>(QDataStream &stream, QAmqpFrame &frame);


### PR DESCRIPTION
Hi,

while trying to use qamqp to implement an application that has to write to a large number of queues (~ 20k) we ran into issues with the server disconnecting us while declaring the queues. Upon inspection we noticed that channelNumber is signed, limiting the range to 32k and nextChannelNumber being incrementing twice per channel, reducing the maximum number of channels to 16k.

These commits fix both of those issues.