### PR TITLE
Configurable writeTimeout 

### DIFF
--- a/src/qamqpclient.cpp
+++ b/src/qamqpclient.cpp
@@ -767,6 +767,16 @@ void QAmqpClient::setHeartbeatDelay(qint16 delay)
     d->heartbeatDelay = delay;
 }
 
+int QAmqpClient::writeTimeout() const
+{
+    return QAmqpFrame::writeTimeout();
+}
+
+void QAmqpClient::setWriteTimeout(int msecs)
+{
+    QAmqpFrame::setWriteTimeout(msecs);
+}
+
 void QAmqpClient::addCustomProperty(const QString &name, const QString &value)
 {
     Q_D(QAmqpClient);

--- a/src/qamqpclient.h
+++ b/src/qamqpclient.h
@@ -80,6 +80,9 @@ public:
     qint16 heartbeatDelay() const;
     void setHeartbeatDelay(qint16 delay);
 
+    int writeTimeout() const;
+    void setWriteTimeout(int msecs);
+
     void addCustomProperty(const QString &name, const QString &value);
     QString customProperty(const QString &name) const;
 

--- a/src/qamqpframe.cpp
+++ b/src/qamqpframe.cpp
@@ -73,7 +73,7 @@ QDataStream &operator<<(QDataStream &stream, const QAmqpFrame &frame)
 
     // write end
     stream << qint8(QAmqpFrame::FRAME_END);
-    stream.device()->waitForBytesWritten(frame.writeTimeout());
+    stream.device()->waitForBytesWritten(QAmqpFrame::writeTimeout());
     return stream;
 }
 

--- a/src/qamqpframe.cpp
+++ b/src/qamqpframe.cpp
@@ -6,6 +6,9 @@
 #include "qamqpglobal.h"
 #include "qamqpframe_p.h"
 
+QReadWriteLock QAmqpFrame::lock_;
+int QAmqpFrame::writeTimeout_ = 1000;
+
 QAmqpFrame::QAmqpFrame(FrameType type)
     : size_(0),
       type_(type),
@@ -25,6 +28,18 @@ QAmqpFrame::~QAmqpFrame()
 void QAmqpFrame::setChannel(quint16 channel)
 {
     channel_ = channel;
+}
+
+int QAmqpFrame::writeTimeout()
+{
+    QReadLocker locker(&lock_);
+    return writeTimeout_;
+}
+
+void QAmqpFrame::setWriteTimeout(int msecs)
+{
+    QWriteLocker locker(&lock_);
+    writeTimeout_ = msecs;
 }
 
 quint16 QAmqpFrame::channel() const
@@ -58,7 +73,7 @@ QDataStream &operator<<(QDataStream &stream, const QAmqpFrame &frame)
 
     // write end
     stream << qint8(QAmqpFrame::FRAME_END);
-    stream.device()->waitForBytesWritten(1000);
+    stream.device()->waitForBytesWritten(frame.writeTimeout());
     return stream;
 }
 

--- a/src/qamqpframe_p.h
+++ b/src/qamqpframe_p.h
@@ -2,6 +2,7 @@
 #define QAMQPFRAME_P_H
 
 #include <QDataStream>
+#include <QReadWriteLock>
 #include <QHash>
 #include <QVariant>
 
@@ -42,6 +43,9 @@ public:
     quint16 channel() const;
     void setChannel(quint16 channel);
 
+    static int writeTimeout();
+    static void setWriteTimeout(int msecs);
+
     virtual qint32 size() const;
 
     static QVariant readAmqpField(QDataStream &s, QAmqpMetaType::ValueType type);
@@ -57,6 +61,9 @@ protected:
 private:
     qint8 type_;
     quint16 channel_;
+
+    static QReadWriteLock lock_;
+    static int writeTimeout_;
 
     friend QDataStream &operator<<(QDataStream &stream, const QAmqpFrame &frame);
     friend QDataStream &operator>>(QDataStream &stream, QAmqpFrame &frame);


### PR DESCRIPTION
Allowing to configure the delay of `waitForBytesWritten` when writing `QAmqpFrame`.