### PR TITLE
Initial stab at test case for Issue 23.

### DIFF
--- a/tests/auto/qamqpqueue/Issue23.cpp
+++ b/tests/auto/qamqpqueue/Issue23.cpp
@@ -1,0 +1,186 @@
+#include <QDebug>
+#include <QTimer>
+#include <QCoreApplication>
+#include "Issue23.h"
+#include "qamqpclient.h"
+#include "qamqpqueue.h"
+#include "qamqpexchange.h"
+
+const QByteArray Issue23Test::MSG_PAYLOAD("Hello AMQP World\n");
+
+Issue23Test::Issue23Test(QAmqpClient* client, QObject* parent)
+: QObject(parent), client(client), default_ex(NULL), queue(NULL),
+  consumers(0), sent(0), passes(0), failures(0), remove_attempted(false)
+{
+    qDebug()    << "INIT: Creating connection";
+    this->timer = new QTimer();
+    this->timer->setSingleShot(true);
+    connect(this->timer, SIGNAL(timeout()),
+            this,        SLOT(timerTimeout()));
+}
+
+void Issue23Test::run()
+{
+    /* Give ourselves 2 seconds to create the queue */
+    this->timer->start(2000);
+
+    qDebug()    << "INIT: Creating exchange";
+    this->timer->stop();
+    this->default_ex    = this->client->createExchange();
+    qDebug()    << "INIT: Creating queue";
+    this->queue        = this->client->createQueue();
+    connect(this->queue, SIGNAL(declared()),
+            this,        SLOT(queueDeclared()));
+    connect(this->queue, SIGNAL(removed()),
+            this,        SLOT(queueRemoved()));
+    connect(this->queue, SIGNAL(consuming(const QString&)),
+            this,        SLOT(queueConsuming(const QString&)));
+    connect(this->queue, SIGNAL(cancelled(const QString&)),
+            this,        SLOT(queueCancelled(const QString&)));
+    connect(this->queue, SIGNAL(messageReceived()),
+            this,        SLOT(queueMessageReceived()));
+    qDebug()    << "INIT: Declaring queue";
+    this->queue->declare(QAmqpQueue::Exclusive);
+}
+
+Issue23Test::~Issue23Test()
+{
+    qDebug()    << "END: Disconnecting from queue";
+    if (this->queue != NULL)
+        disconnect(this->queue, 0, this, 0);
+}
+
+/*!
+ * From signal QAmqpQueue::declared, consume the queue
+ * multiple times.
+ */
+void Issue23Test::queueDeclared()
+{
+    qDebug()    << "DECLARED: Queue declared, named "
+                << this->queue->name()
+                << ", creating multiple consumers.";
+    int count = 5;
+    this->timer->stop();
+    this->timer->start(2000);
+    while(count-- > 0)
+        if (this->queue->consume())
+            this->consumers++;
+        else
+            break;
+
+    qDebug()    << "DECLARED:"
+                << this->consumers
+                << "consumers started";
+}
+
+/*!
+ * From signal QAmqpQueue::consuming, send a test message
+ * to the queue.
+ */
+void Issue23Test::queueConsuming(const QString& consumer_tag)
+{
+    int count=3;
+    qDebug()    << "CONSUMING: ConsumeOk received with tag "
+                << consumer_tag
+                << " sending test messages.";
+    this->timer->stop();
+    this->timer->start(2000);
+    while(count-- > 0) {
+        this->default_ex->publish(Issue23Test::MSG_PAYLOAD,
+            this->queue->name(), "text/plain");
+        this->sent++;
+    }
+    qDebug()    << "CONSUMING: Sent"
+                << this->sent
+                << "messages.";
+}
+
+/*!
+ * From signal QAmqpQueue::cancelled, remove the queue.
+ */
+void Issue23Test::queueCancelled(const QString& consumer_tag)
+{
+    qDebug()    << "CANCELLED: Consumer" << consumer_tag;
+    this->timer->stop();
+    this->tryRemove();
+}
+
+/*!
+ * from signal QAmqpQueue::messageReceived, grab the test
+ * message and inspect its content.
+ */
+void Issue23Test::queueMessageReceived()
+{
+    const QAmqpMessage msg(this->queue->dequeue());
+    qDebug()    << "RECEIVED: Got message, payload:"
+                << msg.payload();
+    this->timer->stop();
+    this->timer->start(2000);
+    if (msg.payload() == Issue23Test::MSG_PAYLOAD) {
+        this->passes++;
+        qDebug() << "RECEIVED: pass";
+    } else {
+        this->failures++;
+        qDebug() << "RECEIVED: fail";
+    }
+}
+
+/*!
+ * from signal QAmqpQueue::removed, shut down.
+ */
+void Issue23Test::queueRemoved()
+{
+    qDebug()    << "REMOVED: Emitting results";
+    this->queue = NULL;
+    this->reportResults();
+}
+
+/*!
+ * from signal QTimer::timeout, disconnect or shut down.
+ */
+void Issue23Test::timerTimeout()
+{
+    qDebug()    << "TIMEOUT: Time is up";
+    if ((this->queue != NULL) 
+            && this->queue->isDeclared()) {
+        if (!this->queue->isConsuming()) {
+            qDebug() << "TIMEOUT: Cancelling consumer...";
+            this->timer->start(2000);
+            this->queue->cancel();
+            return;
+        }
+
+        if (!this->remove_attempted) {
+            qDebug() << "TIMEOUT: Removing queue...";
+            this->tryRemove();
+            return;
+        }
+    }
+    qDebug()    << "TIMEOUT: Emitting results";
+    this->reportResults();
+}
+
+/*! Try to remove the queue */
+void Issue23Test::tryRemove()
+{
+    qDebug()    << "TRYREMOVE: Attempting deletion";
+    this->timer->start(2000);
+    this->remove_attempted = true;
+    this->queue->remove();
+}
+
+/*! Report the results */
+void Issue23Test::reportResults()
+{
+    qDebug()    << "COMPLETE: We created"
+                << this->consumers
+                << "consumers, sent"
+                << this->sent
+                << "messages, received"
+                << this->passes
+                << "good messages and"
+                << this->failures
+                << "bad messages.";
+    emit testComplete(this->consumers, this->sent, this->passes,
+            this->failures);
+}

--- a/tests/auto/qamqpqueue/Issue23.cpp
+++ b/tests/auto/qamqpqueue/Issue23.cpp
@@ -7,6 +7,7 @@
 #include "qamqpexchange.h"
 
 const QByteArray Issue23Test::MSG_PAYLOAD("Hello AMQP World\n");
+const int Issue23Test::NUM_MSGS = 3;
 
 Issue23Test::Issue23Test(QAmqpClient* client, QObject* parent)
 : QObject(parent), client(client), default_ex(NULL), queue(NULL),
@@ -79,7 +80,7 @@ void Issue23Test::queueDeclared()
  */
 void Issue23Test::queueConsuming(const QString& consumer_tag)
 {
-    int count=3;
+    int count=Issue23Test::NUM_MSGS;
     qDebug()    << "CONSUMING: ConsumeOk received with tag "
                 << consumer_tag
                 << " sending test messages.";

--- a/tests/auto/qamqpqueue/Issue23.h
+++ b/tests/auto/qamqpqueue/Issue23.h
@@ -22,6 +22,9 @@ public:
     Issue23Test(QAmqpClient* client, QObject* parent=0);
     ~Issue23Test();
 
+    /*! Number of messages per consumer to send */
+    static int NUM_MSGS;
+
     /*! Our message payload.  We should only see this once. */
     static const QByteArray MSG_PAYLOAD;
 
@@ -31,7 +34,7 @@ public:
 signals:
     /*!
      * Signal indicating when the test is complete.  We should see
-     * consumers == 1, sent == consumers, sent == passes and
+     * consumers == 1, sent == consumers*NUM_MSGS, sent == passes and
      * failures == 0.
      */
     void testComplete(int consumers, int sent,

--- a/tests/auto/qamqpqueue/Issue23.h
+++ b/tests/auto/qamqpqueue/Issue23.h
@@ -1,0 +1,92 @@
+#ifndef _ISSUE23_H
+#define _ISSUE23_H
+
+/*!
+ * @file Issue23.h
+ * Test for possible multiple-consumers on a channel.
+ * Issue 23: https://github.com/mbroadst/qamqp/issues/23
+ */
+
+#include <QByteArray>
+#include <QObject>
+
+class QAmqpClient;
+class QAmqpQueue;
+class QAmqpExchange;
+class QTimer;
+
+class Issue23Test : public QObject {
+Q_OBJECT
+
+public:
+    Issue23Test(QAmqpClient* client, QObject* parent=0);
+    ~Issue23Test();
+
+    /*! Our message payload.  We should only see this once. */
+    static const QByteArray MSG_PAYLOAD;
+
+    /*! Run the test */
+    void run();
+
+signals:
+    /*!
+     * Signal indicating when the test is complete.  We should see
+     * consumers == 1, sent == consumers, sent == passes and
+     * failures == 0.
+     */
+    void testComplete(int consumers, int sent,
+            int passes, int failures);
+
+private slots:
+    /*!
+     * From signal QAmqpQueue::declared, consume the queue
+     * multiple times.
+     */
+    void queueDeclared();
+
+    /*!
+     * From signal QAmqpQueue::removed, indicates test is complete.
+     */
+    void queueRemoved();
+
+    /*!
+     * From signal QAmqpQueue::consuming, send a test message
+     * to the queue.
+     */
+    void queueConsuming(const QString& consumer_tag);
+
+    /*!
+     * From signal QAmqpQueue::cancelled, remove the queue.
+     */
+    void queueCancelled(const QString& consumer_tag);
+
+    /*!
+     * from signal QAmqpQueue::messageReceived, grab the test
+     * message and inspect its content.
+     */
+    void queueMessageReceived();
+
+    /*!
+     * from signal QTimer::timeout, disconnect or shut down.
+     */
+    void timerTimeout();
+private:
+    QAmqpClient*    client;
+    QAmqpExchange*  default_ex;
+    QAmqpQueue*     queue;
+    QTimer*         timer;
+
+    int             consumers;
+    int             sent;
+    int             passes;
+    int             failures;
+    bool            remove_attempted;
+
+    /*! Try to remove the queue */
+    void tryRemove();
+
+    /*! Report the results */
+    void reportResults();
+};
+
+#endif

--- a/tests/auto/qamqpqueue/Issue23.h
+++ b/tests/auto/qamqpqueue/Issue23.h
@@ -23,7 +23,7 @@ public:
     ~Issue23Test();
 
     /*! Number of messages per consumer to send */
-    static int NUM_MSGS;
+    static const int NUM_MSGS;
 
     /*! Our message payload.  We should only see this once. */
     static const QByteArray MSG_PAYLOAD;

--- a/tests/auto/qamqpqueue/qamqpqueue.pro
+++ b/tests/auto/qamqpqueue/qamqpqueue.pro
@@ -3,4 +3,5 @@ include($${DEPTH}/qamqp.pri)
 include($${DEPTH}/tests/tests.pri)
 
 TARGET = tst_qamqpqueue
-SOURCES = tst_qamqpqueue.cpp
+SOURCES = tst_qamqpqueue.cpp Issue23.cpp
+HEADERS = Issue23.h

--- a/tests/auto/qamqpqueue/tst_qamqpqueue.cpp
+++ b/tests/auto/qamqpqueue/tst_qamqpqueue.cpp
@@ -364,7 +364,8 @@ void tst_QAMQPQueue::preventStartConsumerRaceIssue23()
 
     QList<QVariant> arguments = testSpy.takeFirst();
     QVERIFY(arguments.at(0).toInt() == 1);
-    QVERIFY(arguments.at(1).toInt() == arguments.at(0).toInt());
+    QVERIFY(arguments.at(1).toInt() ==
+                    arguments.at(0).toInt() * Issue23Test::NUM_MSGS);
     QVERIFY(arguments.at(2).toInt() == arguments.at(1).toInt());
     QVERIFY(arguments.at(3).toInt() == 0);
 }


### PR DESCRIPTION
This tries to declare a queue, consume it multiple times in quick
succession, then sends a few messages to the queue and receives them
back.  If the bug is fixed, there should only be one consumer created,
each message should be received once and the body should appear once.