### PR TITLE
State-machine based automatic exchange and queue set-up.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,35 @@
 /Debug
 /GeneratedFiles
 build
+# output files from qmake / make
+Makefile
+*.moc
+*.o
+moc_*.cpp
+# vim swapfiles
+.*.swp
+# generated files:
+src/libqamqp.prl
+src/libqamqp.so
+src/libqamqp.so.*
+src/pkgconfig/
+test.log
+tests/auto/qamqpchannel/tst_qamqpchannel
+tests/auto/qamqpclient/qrc_certs.cpp
+tests/auto/qamqpclient/tst_qamqpclient
+tests/auto/qamqpexchange/tst_qamqpexchange
+tests/auto/qamqpqueue/tst_qamqpqueue
+tutorials/helloworld/receive/receive
+tutorials/helloworld/send/send
+tutorials/pubsub/emit_log/emit_log
+tutorials/pubsub/receive_logs/receive_logs
+tutorials/routing/emit_log_direct/emit_log_direct
+tutorials/routing/receive_logs_direct/receive_logs_direct
+tutorials/rpc/rpc_client/moc_fibonaccirpcclient.cpp
+tutorials/rpc/rpc_client/rpc_client
+tutorials/rpc/rpc_server/moc_server.cpp
+tutorials/rpc/rpc_server/rpc_server
+tutorials/topics/emit_log_topic/emit_log_topic
+tutorials/topics/receive_logs_topic/receive_logs_topic
+tutorials/workqueues/new_task/new_task
+tutorials/workqueues/worker/worker

--- a/src/qamqpchannel.cpp
+++ b/src/qamqpchannel.cpp
@@ -267,20 +267,20 @@ void QAmqpChannelPrivate::newState(ChannelState state)
 QDebug operator<<(QDebug dbg, QAmqpChannelPrivate::ChannelState s)
 {
     switch(s) {
-        case QAmqpChannelPrivate::ChannelClosedState:
-            dbg << "ChannelClosedState";
-            break;
-        case QAmqpChannelPrivate::ChannelOpeningState:
-            dbg << "ChannelOpeningState";
-            break;
-        case QAmqpChannelPrivate::ChannelOpenState:
-            dbg << "ChannelOpenState";
-            break;
-        case QAmqpChannelPrivate::ChannelClosingState:
-            dbg << "ChannelClosingState";
-            break;
-        default:
-            dbg << "{UNKNOWN CHANNEL STATE}";
+    case QAmqpChannelPrivate::ChannelClosedState:
+        dbg << "ChannelClosedState";
+        break;
+    case QAmqpChannelPrivate::ChannelOpeningState:
+        dbg << "ChannelOpeningState";
+        break;
+    case QAmqpChannelPrivate::ChannelOpenState:
+        dbg << "ChannelOpenState";
+        break;
+    case QAmqpChannelPrivate::ChannelClosingState:
+        dbg << "ChannelClosingState";
+        break;
+    default:
+        dbg << "{UNKNOWN CHANNEL STATE}";
     }
     return dbg;
 }

--- a/src/qamqpchannel.cpp
+++ b/src/qamqpchannel.cpp
@@ -212,6 +212,7 @@ void QAmqpChannelPrivate::close(const QAmqpMethodFrame &frame)
     QAmqpMethodFrame closeOkFrame(QAmqpFrame::Channel, miCloseOk);
     closeOkFrame.setChannel(channelNumber);
     sendFrame(closeOkFrame);
+    newState(CH_CLOSED);
 }
 
 void QAmqpChannelPrivate::closeOk(const QAmqpMethodFrame &)
@@ -265,9 +266,11 @@ void QAmqpChannelPrivate::qosOk(const QAmqpMethodFrame &frame)
 /*! Report and change state. */
 void QAmqpChannelPrivate::newState(ChannelState state)
 {
-    qAmqpDebug() << "Channel state: "
+    qAmqpDebug() << "Channel"
+                 << name
+                 << "state:"
                  << channelState
-                 << " -> "
+                 << "->"
                  << state;
     channelState = state;
 }

--- a/src/qamqpchannel.cpp
+++ b/src/qamqpchannel.cpp
@@ -157,8 +157,7 @@ void QAmqpChannelPrivate::close(int code, const QString &text, int classId, int 
     QByteArray arguments;
     QDataStream stream(&arguments, QIODevice::WriteOnly);
     if (channelState != ChannelOpenState) {
-        qAmqpDebug()    << Q_FUNC_INFO
-                        << "Channel is not open.";
+        qAmqpDebug() << Q_FUNC_INFO << "Channel is not open.";
         return;
     }
 
@@ -229,8 +228,7 @@ void QAmqpChannelPrivate::openOk(const QAmqpMethodFrame &)
 
     newState(ChannelOpenState);
     if (qosDefined)
-        q->qos(requestedPrefetchCount,
-                requestedPrefetchSize);
+        q->qos(requestedPrefetchCount, requestedPrefetchSize);
 
     Q_EMIT q->opened();
     q->channelOpened();
@@ -255,12 +253,7 @@ void QAmqpChannelPrivate::qosOk(const QAmqpMethodFrame &frame)
 /*! Report and change state. */
 void QAmqpChannelPrivate::newState(ChannelState state)
 {
-    qAmqpDebug() << "Channel"
-                 << name
-                 << "state:"
-                 << channelState
-                 << "->"
-                 << state;
+    qAmqpDebug() << "Channel" << name << "state:" << channelState << "->" << state;
     channelState = state;
 }
 

--- a/src/qamqpchannel_p.h
+++ b/src/qamqpchannel_p.h
@@ -39,6 +39,8 @@ public:
         CH_CLOSED,
         /*! Channel is being opened, pending response. */
         CH_OPENING,
+        /*! Defining QOS parameters for channel. */
+        CH_QOS,
         /*! Channel is open */
         CH_OPEN,
         /*! Channel is being closed, pending response. */
@@ -65,6 +67,12 @@ public:
     void closeOk(const QAmqpMethodFrame &frame);
     void qosOk(const QAmqpMethodFrame &frame);
 
+    /*!
+     * Declare the channel as opened, signal listeners and call the subclass
+     * channelOpened method.
+     */
+    void markOpened();
+
     // private slots
     virtual void _q_disconnected();
     void _q_open();
@@ -76,6 +84,10 @@ public:
     ChannelState channelState;
     bool needOpen;
 
+    /*! Flag: the user has defined QOS settings */
+    bool qosDefined;
+    /*! Flag: channel was open at time of qos call */
+    bool qosWasOpen;
     qint32 prefetchSize;
     qint32 requestedPrefetchSize;
     qint16 prefetchCount;

--- a/src/qamqpchannel_p.h
+++ b/src/qamqpchannel_p.h
@@ -39,8 +39,6 @@ public:
         ChannelClosedState,
         /*! Channel is being opened, pending response. */
         ChannelOpeningState,
-        /*! Defining QOS parameters for channel. */
-        SetQOSState,
         /*! Channel is open */
         ChannelOpenState,
         /*! Channel is being closed, pending response. */
@@ -67,12 +65,6 @@ public:
     void closeOk(const QAmqpMethodFrame &frame);
     void qosOk(const QAmqpMethodFrame &frame);
 
-    /*!
-     * Declare the channel as opened, signal listeners and call the subclass
-     * channelOpened method.
-     */
-    void markOpened();
-
     // private slots
     virtual void _q_disconnected();
     void _q_open();
@@ -89,8 +81,6 @@ public:
 
     /*! Flag: the user has defined QOS settings */
     bool qosDefined;
-    /*! Flag: channel was open at time of qos call */
-    bool qosWasOpen;
     qint32 prefetchSize;
     qint32 requestedPrefetchSize;
     qint16 prefetchCount;

--- a/src/qamqpchannel_p.h
+++ b/src/qamqpchannel_p.h
@@ -34,6 +34,17 @@ public:
         bmNack = 120
     };
 
+    enum ChannelState {
+        /*! Channel is presently closed */
+        CH_CLOSED,
+        /*! Channel is being opened, pending response. */
+        CH_OPENING,
+        /*! Channel is open */
+        CH_OPEN,
+        /*! Channel is being closed, pending response. */
+        CH_CLOSING,
+    };
+
     QAmqpChannelPrivate(QAmqpChannel *q);
     virtual ~QAmqpChannelPrivate();
 
@@ -62,7 +73,7 @@ public:
     QString name;
     quint16 channelNumber;
     static quint16 nextChannelNumber;
-    bool opened;
+    ChannelState channelState;
     bool needOpen;
 
     qint32 prefetchSize;

--- a/src/qamqpchannel_p.h
+++ b/src/qamqpchannel_p.h
@@ -84,6 +84,9 @@ public:
     ChannelState channelState;
     bool needOpen;
 
+    /*! Report and change state. */
+    virtual void newState(ChannelState state);
+
     /*! Flag: the user has defined QOS settings */
     bool qosDefined;
     /*! Flag: channel was open at time of qos call */
@@ -99,5 +102,7 @@ public:
     Q_DECLARE_PUBLIC(QAmqpChannel)
     QAmqpChannel * const q_ptr;
 };
+
+QDebug operator<<(QDebug dbg, QAmqpChannelPrivate::ChannelState s);
 
 #endif // QAMQPCHANNEL_P_H

--- a/src/qamqpchannel_p.h
+++ b/src/qamqpchannel_p.h
@@ -36,15 +36,15 @@ public:
 
     enum ChannelState {
         /*! Channel is presently closed */
-        CH_CLOSED,
+        ChannelClosedState,
         /*! Channel is being opened, pending response. */
-        CH_OPENING,
+        ChannelOpeningState,
         /*! Defining QOS parameters for channel. */
-        CH_QOS,
+        SetQOSState,
         /*! Channel is open */
-        CH_OPEN,
+        ChannelOpenState,
         /*! Channel is being closed, pending response. */
-        CH_CLOSING,
+        ChannelClosingState,
     };
 
     QAmqpChannelPrivate(QAmqpChannel *q);

--- a/src/qamqpchannelhash.cpp
+++ b/src/qamqpchannelhash.cpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2012-2014 Alexey Shcherbakov
+ * Copyright (C) 2014-2015 Matt Broadstone
+ * Contact: https://github.com/mbroadst/qamqp
+ *
+ * This file is part of the QAMQP Library.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ */
+#include "qamqpqueue.h"
+#include "qamqpexchange.h"
+#include "qamqpchannelhash_p.h"
+
+/*!
+* Retrieve a pointer to the named channel.
+*
+* A NULL string is assumed to be equivalent to "" for the purpose
+* of retrieving the nameless (default) exchange.
+*
+* \param[in]   name    The name of the channel to retrieve.
+* \retval      NULL    Channel does not exist.
+*/
+QAmqpChannel* QAmqpChannelHash::get(const QString& name) const
+{
+    if (name.isNull())
+        return channels.value(QString(""));
+    return channels.value(name);
+}
+
+/*!
+* Store an exchange in the hash.  The nameless exchange is stored under
+* the name "".
+*/
+void QAmqpChannelHash::put(QAmqpExchange* exchange)
+{
+    if (exchange->name().isEmpty())
+        put(QString(""), exchange);
+    else
+        put(exchange->name(), exchange);
+}
+
+/*!
+* Store a queue in the hash.  If the queue is nameless, we hook its
+* declared signal and store it when the queue receives a name from the
+* broker, otherwise we store it under the name given.
+*/
+void QAmqpChannelHash::put(QAmqpQueue* queue)
+{
+    if (queue->name().isEmpty())
+        connect(queue,  SIGNAL(declared()),
+                this,   SLOT(queueDeclared()));
+    else
+        put(queue->name(), queue);
+}
+
+/*!
+* Handle destruction of a channel.  Retrieve its current name and
+* remove it from the list, otherwise do a full garbage collection
+* run.
+*/
+void QAmqpChannelHash::channelDestroyed()
+{
+    QAmqpChannel* ch = static_cast<QAmqpChannel*>(sender());
+    if (!channels.contains(ch->name()))
+        return;
+    if (channels[ch->name()] == ch)
+        channels.remove(ch->name());
+}
+
+/*!
+* Handle a queue that has just been declared and given a new name.  The
+* caller is assumed to be a QAmqpQueue instance.
+*/
+void QAmqpChannelHash::queueDeclared()
+{
+    put(static_cast<QAmqpQueue*>(sender()));
+}
+
+/*!
+* Store a channel in the hash.  The channel is assumed
+* to be named at the time of storage.  This hooks the 'destroyed' signal
+* so the channel can be removed from our list.
+*/
+void QAmqpChannelHash::put(const QString& name, QAmqpChannel* channel)
+{
+    connect(channel,    SIGNAL(destroyed()),
+            this,       SLOT(channelDestroyed()));
+    channels[name] = channel;
+}
+
+#include "moc_qamqpchannelhash_p.cpp"
+/* vim: set ts=4 sw=4 et */

--- a/src/qamqpchannelhash.cpp
+++ b/src/qamqpchannelhash.cpp
@@ -62,17 +62,16 @@ void QAmqpChannelHash::put(QAmqpQueue* queue)
 }
 
 /*!
-* Handle destruction of a channel.  Retrieve its current name and
-* remove it from the list, otherwise do a full garbage collection
-* run.
+* Handle destruction of a channel.  Do a full garbage collection run.
 */
-void QAmqpChannelHash::channelDestroyed()
+void QAmqpChannelHash::channelDestroyed(QObject* object)
 {
-    QAmqpChannel* ch = static_cast<QAmqpChannel*>(sender());
-    if (!channels.contains(ch->name()))
-        return;
-    if (channels[ch->name()] == ch)
-        channels.remove(ch->name());
+    QList<QString> names(channels.keys());
+    QList<QString>::iterator it;
+    for (it = names.begin(); it != names.end(); it++) {
+        if (channels.value(*it) == object)
+            channels.remove(*it);
+    }
 }
 
 /*!
@@ -91,8 +90,8 @@ void QAmqpChannelHash::queueDeclared()
 */
 void QAmqpChannelHash::put(const QString& name, QAmqpChannel* channel)
 {
-    connect(channel,    SIGNAL(destroyed()),
-            this,       SLOT(channelDestroyed()));
+    connect(channel,    SIGNAL(destroyed(QObject*)),
+            this,       SLOT(channelDestroyed(QObject*)));
     channels[name] = channel;
 }
 

--- a/src/qamqpchannelhash_p.h
+++ b/src/qamqpchannelhash_p.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2012-2014 Alexey Shcherbakov
+ * Copyright (C) 2014-2015 Matt Broadstone
+ * Contact: https://github.com/mbroadst/qamqp
+ *
+ * This file is part of the QAMQP Library.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ */
+#ifndef QAMQPCHANNELHASH_P_H
+#define QAMQPCHANNELHASH_P_H
+
+#include <QHash>
+#include <QString>
+#include <QObject>
+
+/* Forward declarations */
+class QAmqpChannel;
+class QAmqpQueue;
+class QAmqpExchange;
+
+/*!
+ * QAmqpChannelHash is a container for storing queues and exchanges for later
+ * retrieval.  When the objects are destroyed, they are automatically removed
+ * from the container.
+ */
+class QAmqpChannelHash : public QObject
+{
+    Q_OBJECT
+public:
+    /*!
+     * Retrieve a pointer to the named channel.
+     *
+     * A NULL string is assumed to be equivalent to "" for the purpose
+     * of retrieving the nameless (default) exchange.
+     *
+     * \param[in]   name    The name of the channel to retrieve.
+     * \retval      NULL    Channel does not exist.
+     */
+    QAmqpChannel* get(const QString& name) const;
+
+    /*!
+     * Store an exchange in the hash.  The nameless exchange is stored under
+     * the name "".
+     */
+    void put(QAmqpExchange* exchange);
+
+    /*!
+     * Store a queue in the hash.  If the queue is nameless, we hook its
+     * declared signal and store it when the queue receives a name from the
+     * broker, otherwise we store it under the name given.
+     */
+    void put(QAmqpQueue* queue);
+
+private Q_SLOTS:
+    /*!
+     * Handle destruction of a channel.  Retrieve its current name and
+     * remove it from the list, otherwise do a full garbage collection
+     * run.
+     */
+    void channelDestroyed();
+
+    /*!
+     * Handle a queue that has just been declared and given a new name.  The
+     * caller is assumed to be a QAmqpQueue instance.
+     */
+    void queueDeclared();
+
+private:
+    /*!
+     * Store a channel in the hash.  This hooks the 'destroyed' signal
+     * so the channel can be removed from our list.
+     */
+    void put(const QString& name, QAmqpChannel* channel);
+
+    /*! A collection of channels.  Key is the channel's "name". */
+    QHash<QString, QAmqpChannel*> channels;
+};
+
+/* vim: set ts=4 sw=4 et */
+#endif

--- a/src/qamqpchannelhash_p.h
+++ b/src/qamqpchannelhash_p.h
@@ -62,11 +62,9 @@ public:
 
 private Q_SLOTS:
     /*!
-     * Handle destruction of a channel.  Retrieve its current name and
-     * remove it from the list, otherwise do a full garbage collection
-     * run.
+     * Handle destruction of a channel.  Do a full garbage collection run.
      */
-    void channelDestroyed();
+    void channelDestroyed(QObject* object);
 
     /*!
      * Handle a queue that has just been declared and given a new name.  The

--- a/src/qamqpclient.cpp
+++ b/src/qamqpclient.cpp
@@ -672,15 +672,16 @@ QAmqpExchange *QAmqpClient::createExchange(const QString &name, int channelNumbe
 
     if (!name.isEmpty())
         exchange->setName(name);
-    else if (name.isNull())
+    if (name.isNull())
         /*
          * We don't want two copies of the default exchange, one referenced by
          * QString() and the other by QString("").  QString() != QString("")  So
          * if it's null, overwrite with the empty string, since that's its
          * official name.
          */
-        name = "";
-    d->exchanges[name] = exchange;
+        d->exchanges[""] = exchange;
+    else
+        d->exchanges[name] = exchange;
     return exchange;
 }
 

--- a/src/qamqpclient.cpp
+++ b/src/qamqpclient.cpp
@@ -670,10 +670,17 @@ QAmqpExchange *QAmqpClient::createExchange(const QString &name, int channelNumbe
     connect(this, SIGNAL(disconnected()), exchange, SLOT(_q_disconnected()));
     exchange->d_func()->open();
 
-    if (!name.isEmpty()) {
+    if (!name.isEmpty())
         exchange->setName(name);
-        d->exchanges[name] = exchange;
-    }
+    else if (name.isNull())
+        /*
+         * We don't want two copies of the default exchange, one referenced by
+         * QString() and the other by QString("").  QString() != QString("")  So
+         * if it's null, overwrite with the empty string, since that's its
+         * official name.
+         */
+        name = "";
+    d->exchanges[name] = exchange;
     return exchange;
 }
 

--- a/src/qamqpclient.cpp
+++ b/src/qamqpclient.cpp
@@ -660,14 +660,19 @@ QAmqpExchange *QAmqpClient::createExchange(int channelNumber)
 QAmqpExchange *QAmqpClient::createExchange(const QString &name, int channelNumber)
 {
     Q_D(QAmqpClient);
+    if (!name.isEmpty() && d->exchanges.contains(name))
+        return d->exchanges[name];
+
     QAmqpExchange *exchange = new QAmqpExchange(channelNumber, this);
     d->methodHandlersByChannel[exchange->channelNumber()].append(exchange->d_func());
     connect(this, SIGNAL(connected()), exchange, SLOT(_q_open()));
     connect(this, SIGNAL(disconnected()), exchange, SLOT(_q_disconnected()));
     exchange->d_func()->open();
 
-    if (!name.isEmpty())
+    if (!name.isEmpty()) {
         exchange->setName(name);
+        d->exchanges[name] = exchange;
+    }
     return exchange;
 }
 
@@ -679,6 +684,9 @@ QAmqpQueue *QAmqpClient::createQueue(int channelNumber)
 QAmqpQueue *QAmqpClient::createQueue(const QString &name, int channelNumber)
 {
     Q_D(QAmqpClient);
+    if (!name.isEmpty() && d->queues.contains(name))
+        return d->queues[name];
+
     QAmqpQueue *queue = new QAmqpQueue(channelNumber, this);
     d->methodHandlersByChannel[queue->channelNumber()].append(queue->d_func());
     d->contentHandlerByChannel[queue->channelNumber()].append(queue->d_func());
@@ -687,8 +695,10 @@ QAmqpQueue *QAmqpClient::createQueue(const QString &name, int channelNumber)
     connect(this, SIGNAL(disconnected()), queue, SLOT(_q_disconnected()));
     queue->d_func()->open();
 
-    if (!name.isEmpty())
+    if (!name.isEmpty()) {
         queue->setName(name);
+        d->queues[name] = queue;
+    }
     return queue;
 }
 

--- a/src/qamqpclient.cpp
+++ b/src/qamqpclient.cpp
@@ -560,14 +560,14 @@ void QAmqpClientPrivate::_q_objectDestroyed()
     QHash<QString, QPointer<QAmqpExchange> > exchanges(this->exchanges);
     QHash<QString, QPointer<QAmqpExchange> >::iterator ex_it;
     for (ex_it = exchanges.begin() ; ex_it != exchanges.end(); ex_it++)
-        if (ex_it.value.isNull())
+        if (ex_it.value().isNull())
             this->exchanges.remove(ex_it.key());
 
     /* Clean up Queues */
     QHash<QString, QPointer<QAmqpQueue> > queues(this->queues);
     QHash<QString, QPointer<QAmqpQueue> >::iterator q_it;
     for (q_it = queues.begin() ; q_it != queues.end(); q_it++)
-        if (q_it.value.isNull())
+        if (q_it.value().isNull())
             this->queues.remove(q_it.key());
 }
 

--- a/src/qamqpclient.cpp
+++ b/src/qamqpclient.cpp
@@ -660,8 +660,9 @@ QAmqpExchange *QAmqpClient::createExchange(int channelNumber)
 QAmqpExchange *QAmqpClient::createExchange(const QString &name, int channelNumber)
 {
     Q_D(QAmqpClient);
-    if (!name.isEmpty() && d->exchanges.contains(name))
-        return d->exchanges[name];
+    if (!name.isEmpty() && d->exchanges.contains(name)
+                    && (!d->exchanges[name].isNull()))
+        return d->exchanges[name].data();
 
     QAmqpExchange *exchange = new QAmqpExchange(channelNumber, this);
     d->methodHandlersByChannel[exchange->channelNumber()].append(exchange->d_func());
@@ -684,8 +685,9 @@ QAmqpQueue *QAmqpClient::createQueue(int channelNumber)
 QAmqpQueue *QAmqpClient::createQueue(const QString &name, int channelNumber)
 {
     Q_D(QAmqpClient);
-    if (!name.isEmpty() && d->queues.contains(name))
-        return d->queues[name];
+    if (!name.isEmpty() && d->queues.contains(name)
+                    && (!d->queues[name].isNull()))
+        return d->queues[name].data();
 
     QAmqpQueue *queue = new QAmqpQueue(channelNumber, this);
     d->methodHandlersByChannel[queue->channelNumber()].append(queue->d_func());

--- a/src/qamqpclient.h
+++ b/src/qamqpclient.h
@@ -133,6 +133,7 @@ private:
     Q_PRIVATE_SLOT(d_func(), void _q_heartbeat())
     Q_PRIVATE_SLOT(d_func(), void _q_connect())
     Q_PRIVATE_SLOT(d_func(), void _q_disconnect())
+    Q_PRIVATE_SLOT(d_func(), void _q_objectDestroyed())
 
     friend class QAmqpChannelPrivate;
     friend class QAmqpQueuePrivate;

--- a/src/qamqpclient.h
+++ b/src/qamqpclient.h
@@ -133,7 +133,6 @@ private:
     Q_PRIVATE_SLOT(d_func(), void _q_heartbeat())
     Q_PRIVATE_SLOT(d_func(), void _q_connect())
     Q_PRIVATE_SLOT(d_func(), void _q_disconnect())
-    Q_PRIVATE_SLOT(d_func(), void _q_objectDestroyed())
 
     friend class QAmqpChannelPrivate;
     friend class QAmqpQueuePrivate;

--- a/src/qamqpclient_p.h
+++ b/src/qamqpclient_p.h
@@ -51,6 +51,11 @@ public:
     virtual void _q_connect();
     void _q_disconnect();
 
+    /*!
+     * Iterate through our list of objects and clean up the NULL pointers.
+     */
+    void _q_objectDestroyed();
+
     virtual bool _q_method(const QAmqpMethodFrame &frame);
 
     // method handlers, FROM server

--- a/src/qamqpclient_p.h
+++ b/src/qamqpclient_p.h
@@ -101,10 +101,10 @@ public:
     QString errorString;
 
     /*! Exchange objects */
-    QHash<QString, QAmqpExchange*> exchanges;
+    QHash<QString, QPointer<QAmqpExchange> > exchanges;
 
     /*! Named queue objects */
-    QHash<QString, QAmqpQueue*> queues;
+    QHash<QString, QPointer<QAmqpQueue> > queues;
 
     QAmqpClient * const q_ptr;
     Q_DECLARE_PUBLIC(QAmqpClient)

--- a/src/qamqpclient_p.h
+++ b/src/qamqpclient_p.h
@@ -7,6 +7,7 @@
 #include <QAbstractSocket>
 #include <QSslError>
 
+#include "qamqpchannelhash_p.h"
 #include "qamqpglobal.h"
 #include "qamqpauthenticator.h"
 #include "qamqptable.h"
@@ -50,11 +51,6 @@ public:
     void _q_heartbeat();
     virtual void _q_connect();
     void _q_disconnect();
-
-    /*!
-     * Iterate through our list of objects and clean up the NULL pointers.
-     */
-    void _q_objectDestroyed();
 
     virtual bool _q_method(const QAmqpMethodFrame &frame);
 
@@ -106,10 +102,10 @@ public:
     QString errorString;
 
     /*! Exchange objects */
-    QHash<QString, QPointer<QAmqpExchange> > exchanges;
+    QAmqpChannelHash exchanges;
 
     /*! Named queue objects */
-    QHash<QString, QPointer<QAmqpQueue> > queues;
+    QAmqpChannelHash queues;
 
     QAmqpClient * const q_ptr;
     Q_DECLARE_PUBLIC(QAmqpClient)

--- a/src/qamqpclient_p.h
+++ b/src/qamqpclient_p.h
@@ -100,6 +100,12 @@ public:
     QAMQP::Error error;
     QString errorString;
 
+    /*! Exchange objects */
+    QHash<QString, QAmqpExchange*> exchanges;
+
+    /*! Named queue objects */
+    QHash<QString, QAmqpQueue*> queues;
+
     QAmqpClient * const q_ptr;
     Q_DECLARE_PUBLIC(QAmqpClient)
 

--- a/src/qamqpexchange.cpp
+++ b/src/qamqpexchange.cpp
@@ -222,10 +222,7 @@ void QAmqpExchangePrivate::handleAckOrNack(const QAmqpMethodFrame &frame)
 /*! Report and change state. */
 void QAmqpExchangePrivate::newState(ExchangeState state)
 {
-    qAmqpDebug() << "Exchange state: "
-                 << exchangeState
-                 << " -> "
-                 << state;
+    qAmqpDebug() << "Exchange" << name << "state:" << exchangeState << "->" << state;
     exchangeState = state;
 }
 

--- a/src/qamqpexchange.cpp
+++ b/src/qamqpexchange.cpp
@@ -33,7 +33,7 @@ QAmqpExchangePrivate::QAmqpExchangePrivate(QAmqpExchange *q)
 void QAmqpExchangePrivate::declare()
 {
     Q_Q(QAmqpExchange);
-    if (!q->isOpen()) {
+    if (channelState != ChannelClosedState) {
         qAmqpDebug()    << Q_FUNC_INFO
                         << "Channel is closed, re-opening and delaying declare.";
         delayedDeclare = true;

--- a/src/qamqpexchange.cpp
+++ b/src/qamqpexchange.cpp
@@ -299,6 +299,12 @@ void QAmqpExchange::channelClosed()
 {
     Q_D(QAmqpExchange);
     qAmqpDebug() << "Channel closed";
+
+    if (!(name().isEmpty() || name().startsWith("amq.")))
+        d->delayedDeclare = (d->exchangeState
+                == QAmqpExchangePrivate::ExchangeDeclaredState)
+            || (d->exchangeState
+                    == QAmqpExchangePrivate::ExchangeDeclaringState);
     d->newState(QAmqpExchangePrivate::ExchangeClosedState);
 }
 

--- a/src/qamqpexchange.cpp
+++ b/src/qamqpexchange.cpp
@@ -342,7 +342,7 @@ void QAmqpExchange::declare(const QString &type, ExchangeOptions options, const 
 void QAmqpExchange::remove(int options)
 {
     Q_D(QAmqpExchange);
-    if (!isOpen()) {
+    if (d->channelState != QAmqpChannelPrivate::ChannelClosedState) {
         qAmqpDebug() << Q_FUNC_INFO << "Channel is closed, re-opening and delaying remove.";
         d->delayedDeclare = false;
         d->delayedRemove = true;

--- a/src/qamqpexchange.cpp
+++ b/src/qamqpexchange.cpp
@@ -33,12 +33,14 @@ QAmqpExchangePrivate::QAmqpExchangePrivate(QAmqpExchange *q)
 void QAmqpExchangePrivate::declare()
 {
     Q_Q(QAmqpExchange);
-    if (channelState != ChannelClosedState) {
+    if (channelState != ChannelOpenState) {
         qAmqpDebug() << Q_FUNC_INFO << "Channel is closed, re-opening and delaying declare.";
         delayedDeclare = true;
         delayedRemove = false;
-        needOpen = true;
-        q->reopen();
+        if (channelState == ChannelClosedState) {
+            needOpen = true;
+            q->reopen();
+        }
         return;
     }
 
@@ -342,13 +344,15 @@ void QAmqpExchange::declare(const QString &type, ExchangeOptions options, const 
 void QAmqpExchange::remove(int options)
 {
     Q_D(QAmqpExchange);
-    if (d->channelState != QAmqpChannelPrivate::ChannelClosedState) {
+    if (d->channelState != QAmqpChannelPrivate::ChannelOpenState) {
         qAmqpDebug() << Q_FUNC_INFO << "Channel is closed, re-opening and delaying remove.";
         d->delayedDeclare = false;
         d->delayedRemove = true;
-        d->needOpen = true;
         d->removeOptions = options;
-        reopen();
+        if (d->channelState == QAmqpChannelPrivate::ChannelClosedState) {
+            d->needOpen = true;
+            reopen();
+        }
         return;
     }
 

--- a/src/qamqpexchange.cpp
+++ b/src/qamqpexchange.cpp
@@ -207,6 +207,13 @@ QAmqpExchange::~QAmqpExchange()
 void QAmqpExchange::channelOpened()
 {
     Q_D(QAmqpExchange);
+    if (name().isEmpty()) {
+        /* Nameless exchange, we should consider this declared by default */
+        exchangeState = EX_DECLARED;
+        Q_EMIT q->declared();
+        return;
+    }
+
     if (d->delayedDeclare)
         d->declare();
 }

--- a/src/qamqpexchange.cpp
+++ b/src/qamqpexchange.cpp
@@ -31,7 +31,7 @@ QAmqpExchangePrivate::QAmqpExchangePrivate(QAmqpExchange *q)
 
 void QAmqpExchangePrivate::declare()
 {
-    if (!opened) {
+    if (channelState != CH_OPEN) {
         delayedDeclare = true;
         return;
     }

--- a/src/qamqpexchange.cpp
+++ b/src/qamqpexchange.cpp
@@ -209,8 +209,8 @@ void QAmqpExchange::channelOpened()
     Q_D(QAmqpExchange);
     if (name().isEmpty()) {
         /* Nameless exchange, we should consider this declared by default */
-        exchangeState = EX_DECLARED;
-        Q_EMIT q->declared();
+        d->exchangeState = QAmqpExchangePrivate::EX_DECLARED;
+        Q_EMIT declared();
         return;
     }
 

--- a/src/qamqpexchange.cpp
+++ b/src/qamqpexchange.cpp
@@ -238,23 +238,23 @@ void QAmqpExchangePrivate::newState(ChannelState state)
 QDebug operator<<(QDebug dbg, QAmqpExchangePrivate::ExchangeState s)
 {
     switch(s) {
-        case QAmqpExchangePrivate::ExchangeClosedState:
-            dbg << "ExchangeClosedState";
-            break;
-        case QAmqpExchangePrivate::ExchangeUndeclaredState:
-            dbg << "ExchangeUndeclaredState";
-            break;
-        case QAmqpExchangePrivate::ExchangeDeclaringState:
-            dbg << "ExchangeDeclaringState";
-            break;
-        case QAmqpExchangePrivate::ExchangeDeclaredState:
-            dbg << "ExchangeDeclaredState";
-            break;
-        case QAmqpExchangePrivate::ExchangeRemovingState:
-            dbg << "ExchangeRemovingState";
-            break;
-        default:
-            dbg << "{UNKNOWN EXCHANGE STATE}";
+    case QAmqpExchangePrivate::ExchangeClosedState:
+        dbg << "ExchangeClosedState";
+        break;
+    case QAmqpExchangePrivate::ExchangeUndeclaredState:
+        dbg << "ExchangeUndeclaredState";
+        break;
+    case QAmqpExchangePrivate::ExchangeDeclaringState:
+        dbg << "ExchangeDeclaringState";
+        break;
+    case QAmqpExchangePrivate::ExchangeDeclaredState:
+        dbg << "ExchangeDeclaredState";
+        break;
+    case QAmqpExchangePrivate::ExchangeRemovingState:
+        dbg << "ExchangeRemovingState";
+        break;
+    default:
+        dbg << "{UNKNOWN EXCHANGE STATE}";
     }
     return dbg;
 }

--- a/src/qamqpexchange.cpp
+++ b/src/qamqpexchange.cpp
@@ -34,8 +34,7 @@ void QAmqpExchangePrivate::declare()
 {
     Q_Q(QAmqpExchange);
     if (channelState != ChannelClosedState) {
-        qAmqpDebug()    << Q_FUNC_INFO
-                        << "Channel is closed, re-opening and delaying declare.";
+        qAmqpDebug() << Q_FUNC_INFO << "Channel is closed, re-opening and delaying declare.";
         delayedDeclare = true;
         delayedRemove = false;
         needOpen = true;
@@ -344,8 +343,7 @@ void QAmqpExchange::remove(int options)
 {
     Q_D(QAmqpExchange);
     if (!isOpen()) {
-        qAmqpDebug()    << Q_FUNC_INFO
-                        << "Channel is closed, re-opening and delaying remove.";
+        qAmqpDebug() << Q_FUNC_INFO << "Channel is closed, re-opening and delaying remove.";
         d->delayedDeclare = false;
         d->delayedRemove = true;
         d->needOpen = true;

--- a/src/qamqpexchange_p.h
+++ b/src/qamqpexchange_p.h
@@ -51,7 +51,13 @@ public:
     qlonglong nextDeliveryTag;
     QVector<qlonglong> unconfirmedDeliveryTags;
 
+    /*! Report and change state. */
+    virtual void newState(ChannelState state);
+    virtual void newState(ExchangeState state);
+
     Q_DECLARE_PUBLIC(QAmqpExchange)
 };
+
+QDebug operator<<(QDebug dbg, QAmqpExchangePrivate::ExchangeState s);
 
 #endif // QAMQPEXCHANGE_P_H

--- a/src/qamqpexchange_p.h
+++ b/src/qamqpexchange_p.h
@@ -17,6 +17,19 @@ public:
         METHOD_ID_ENUM(cmConfirm, 10)
     };
 
+    enum ExchangeState {
+        /*! Exchange channel is closed */
+        EX_CLOSED,
+        /*! Exchange is undeclared */
+        EX_UNDECLARED,
+        /*! Exchange is being declared */
+        EX_DECLARING,
+        /*! Exchange is declared */
+        EX_DECLARED,
+        /*! Exchange is being removed */
+        EX_REMOVING,
+    };
+
     QAmqpExchangePrivate(QAmqpExchange *q);
     static QString typeToString(QAmqpExchange::ExchangeType type);
 
@@ -34,7 +47,7 @@ public:
     QAmqpExchange::ExchangeOptions options;
     QAmqpTable arguments;
     bool delayedDeclare;
-    bool declared;
+    ExchangeState exchangeState;
     qlonglong nextDeliveryTag;
     QVector<qlonglong> unconfirmedDeliveryTags;
 

--- a/src/qamqpexchange_p.h
+++ b/src/qamqpexchange_p.h
@@ -19,15 +19,15 @@ public:
 
     enum ExchangeState {
         /*! Exchange channel is closed */
-        EX_CLOSED,
+        ExchangeClosedState,
         /*! Exchange is undeclared */
-        EX_UNDECLARED,
+        ExchangeUndeclaredState,
         /*! Exchange is being declared */
-        EX_DECLARING,
+        ExchangeDeclaringState,
         /*! Exchange is declared */
-        EX_DECLARED,
+        ExchangeDeclaredState,
         /*! Exchange is being removed */
-        EX_REMOVING,
+        ExchangeRemovingState,
     };
 
     QAmqpExchangePrivate(QAmqpExchange *q);

--- a/src/qamqpexchange_p.h
+++ b/src/qamqpexchange_p.h
@@ -45,8 +45,10 @@ public:
 
     QString type;
     QAmqpExchange::ExchangeOptions options;
+    int removeOptions;
     QAmqpTable arguments;
     bool delayedDeclare;
+    bool delayedRemove;
     ExchangeState exchangeState;
     qlonglong nextDeliveryTag;
     QVector<qlonglong> unconfirmedDeliveryTags;

--- a/src/qamqpqueue.cpp
+++ b/src/qamqpqueue.cpp
@@ -15,12 +15,11 @@ using namespace QAMQP;
 QAmqpQueuePrivate::QAmqpQueuePrivate(QAmqpQueue *q)
     : QAmqpChannelPrivate(q),
       delayedDeclare(false),
-      declared(false),
+      queueState(Q_CLOSED),
       receivingMessage(false),
       consumeOptions(0),
-      consuming(false),
-      delayedConsume(false),
-      consumeRequested(false)
+      consumerState(C_UNDECLARED),
+      delayedConsume(false)
 {
 }
 
@@ -139,7 +138,8 @@ void QAmqpQueuePrivate::declareOk(const QAmqpMethodFrame &frame)
 {
     Q_Q(QAmqpQueue);
     qAmqpDebug() << "declared queue: " << name;
-    declared = true;
+    queueState = Q_DECLARED;
+    consumerState = C_DECLARED;
 
     QByteArray data = frame.arguments();
     QDataStream stream(&data, QIODevice::ReadOnly);
@@ -148,6 +148,11 @@ void QAmqpQueuePrivate::declareOk(const QAmqpMethodFrame &frame)
     qint32 messageCount = 0, consumerCount = 0;
     stream >> messageCount >> consumerCount;
     qAmqpDebug("message count %d\nConsumer count: %d", messageCount, consumerCount);
+
+    if (delayedConsume)
+        q->consume(consumeOptions);
+    else
+        processBindings();
 
     Q_EMIT q->declared();
 }
@@ -170,7 +175,8 @@ void QAmqpQueuePrivate::deleteOk(const QAmqpMethodFrame &frame)
 {
     Q_Q(QAmqpQueue);
     qAmqpDebug() << "deleted queue: " << name;
-    declared = false;
+    queueState = Q_UNDECLARED;
+    consumerState = C_UNDECLARED;
 
     QByteArray data = frame.arguments();
     QDataStream stream(&data, QIODevice::ReadOnly);
@@ -186,8 +192,23 @@ void QAmqpQueuePrivate::bindOk(const QAmqpMethodFrame &frame)
     Q_UNUSED(frame)
 
     Q_Q(QAmqpQueue);
-    qAmqpDebug() << Q_FUNC_INFO << "bound to exchange";
+    qAmqpDebug() << Q_FUNC_INFO << "bound to exchange"
+        << bindPendingExchange << "key" << bindPendingKey;
     Q_EMIT q->bound();
+
+    QString exchangeName(bindPendingExchange);
+    QString key(bindPendingKey);
+
+    bindPendingExchange.clear();
+    bindPendingKey.clear();
+
+    if (exchangeName.isEmpty() || key.isEmpty())
+        return;
+
+    SubscriptionState& state(getState(exchangeName));
+    state.topicsToBind.remove(key);
+    state.topics << key;
+    processBindings();
 }
 
 void QAmqpQueuePrivate::unbindOk(const QAmqpMethodFrame &frame)
@@ -195,8 +216,24 @@ void QAmqpQueuePrivate::unbindOk(const QAmqpMethodFrame &frame)
     Q_UNUSED(frame)
 
     Q_Q(QAmqpQueue);
-    qAmqpDebug() << Q_FUNC_INFO << "unbound from exchange";
+    qAmqpDebug() << Q_FUNC_INFO << "unbound from exchange"
+        << bindPendingExchange << "key" << bindPendingKey;
     Q_EMIT q->unbound();
+
+    QString exchangeName(bindPendingExchange);
+    QString key(bindPendingKey);
+
+    bindPendingExchange.clear();
+    bindPendingKey.clear();
+
+    if (exchangeName.isEmpty() || key.isEmpty())
+        return;
+
+    SubscriptionState& state(getState(exchangeName));
+    state.topicsToUnbind.remove(key);
+    state.topics.remove(key);
+    processBindings();
+
 }
 
 void QAmqpQueuePrivate::getOk(const QAmqpMethodFrame &frame)
@@ -220,9 +257,9 @@ void QAmqpQueuePrivate::consumeOk(const QAmqpMethodFrame &frame)
     QDataStream stream(&data, QIODevice::ReadOnly);
     consumerTag = QAmqpFrame::readAmqpField(stream, QAmqpMetaType::ShortString).toString();
     qAmqpDebug("consumer tag = %s", qPrintable(consumerTag));
-    consuming = true;
-    consumeRequested = false;
+    consumerState = C_CONSUMING;
     delayedConsume = false;
+    processBindings();
     Q_EMIT q->consuming(consumerTag);
 }
 
@@ -278,10 +315,127 @@ void QAmqpQueuePrivate::cancelOk(const QAmqpMethodFrame &frame)
     }
 
     consumerTag.clear();
-    consuming = false;
-    consumeRequested = false;
+    consumerState = C_DECLARED;
     delayedConsume = false;
     Q_EMIT q->cancelled(consumer);
+}
+
+/*!
+ * Retrieve the state of an exchange's bindings.
+ */
+QAmqpQueuePrivate::SubscriptionState&
+QAmqpQueuePrivate::getState(const QString& exchangeName)
+{
+    SubscriptionState& state = bindings[exchangeName];
+    if (state.exchange == NULL)
+        state.exchange = client->createExchange(exchangeName);
+    return state;
+}
+
+/*!
+ * Reset the binding state.  This marks all presently "subscribed" exchanges
+ * and keys as "to be subscribed" except those presently marked as "to be
+ * unsubscribed".
+ */
+void QAmqpQueuePrivate::resetBindings()
+{
+    /* Reset the current binding operation */
+    bindPendingExchange.clear();
+    bindPendingKey.clear();
+
+    /* Get a list of all bindings */
+    QHash<QString, SubscriptionState> bindings(this->bindings);
+    QHash<QString, SubscriptionState>::iterator bIt;
+
+    for (bIt = bindings.begin(); bIt != bindings.end(); bIt++) {
+        SubscriptionState&  state(bIt.value());
+
+        /* Remove all contents of the "to unbind" from "currently bound" */
+        state.topics.subtract(state.topicsToUnbind);
+
+        /* Add the contents of "currently bound" to "to bind" */
+        state.topicsToBind.unite(state.topics);
+
+        /*
+         * Clear out the currently bound topics.  We leave the contents of
+         * toUnbind alone, since the queue may still exist and still have those
+         * exchanges/keys bound to it.
+         */
+        state.topics.clear();
+    }
+    this->bindings = bindings;
+}
+
+/*!
+ * Process binding list.
+ */
+void QAmqpQueuePrivate::processBindings()
+{
+    /* Do not proceed if a bind or unbind is pending. */
+    if (!bindPendingExchange.isEmpty())
+        return;
+
+    /* Get a list of all bindings */
+    QHash<QString, SubscriptionState> bindings(this->bindings);
+    QHash<QString, SubscriptionState>::iterator bIt;
+    QSet<QString>::iterator tIt;
+
+    for (bIt = bindings.begin(); bIt != bindings.end(); bIt++) {
+        QString             exchangeName(bIt.key());
+        SubscriptionState&  state(bIt.value());
+
+        /* Check for bindings to create */
+        for (tIt = state.topicsToBind.begin();
+                tIt != state.topicsToBind.end();
+                tIt++) {
+            QString         key(*tIt);
+            bindPendingExchange = exchangeName;
+            bindPendingKey = key;
+
+            QAmqpMethodFrame frame(QAmqpFrame::Queue, QAmqpQueuePrivate::miBind);
+            frame.setChannel(channelNumber);
+
+            QByteArray arguments;
+            QDataStream out(&arguments, QIODevice::WriteOnly);
+
+            out << qint16(0);   //  reserved 1
+            QAmqpFrame::writeAmqpField(out, QAmqpMetaType::ShortString, name);
+            QAmqpFrame::writeAmqpField(out, QAmqpMetaType::ShortString, exchangeName);
+            QAmqpFrame::writeAmqpField(out, QAmqpMetaType::ShortString, key);
+
+            out << qint8(0);    //  no-wait
+            QAmqpFrame::writeAmqpField(out, QAmqpMetaType::Hash, QAmqpTable());
+
+            frame.setArguments(arguments);
+            sendFrame(frame);
+            /* Stop processing the list here */
+            return;
+        }
+
+        /* Check for bindings to destroy */
+        for (tIt = state.topicsToUnbind.begin();
+                tIt != state.topicsToUnbind.end();
+                tIt++) {
+            QString         key(*tIt);
+            bindPendingExchange = exchangeName;
+            bindPendingKey = key;
+
+            QAmqpMethodFrame frame(QAmqpFrame::Queue, QAmqpQueuePrivate::miUnbind);
+            frame.setChannel(channelNumber);
+
+            QByteArray arguments;
+            QDataStream out(&arguments, QIODevice::WriteOnly);
+            out << qint16(0);   //reserved 1
+            QAmqpFrame::writeAmqpField(out, QAmqpMetaType::ShortString, name);
+            QAmqpFrame::writeAmqpField(out, QAmqpMetaType::ShortString, exchangeName);
+            QAmqpFrame::writeAmqpField(out, QAmqpMetaType::ShortString, key);
+            QAmqpFrame::writeAmqpField(out, QAmqpMetaType::Hash, QAmqpTable());
+
+            frame.setArguments(arguments);
+            sendFrame(frame);
+            return;
+        }
+    }
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -300,25 +454,17 @@ QAmqpQueue::~QAmqpQueue()
 void QAmqpQueue::channelOpened()
 {
     Q_D(QAmqpQueue);
+    d->resetBindings();
     if (d->delayedDeclare)
         d->declare();
-
-    if (!d->delayedBindings.isEmpty()) {
-        typedef QPair<QString, QString> BindingPair;
-        foreach(BindingPair binding, d->delayedBindings)
-            bind(binding.first, binding.second);
-        d->delayedBindings.clear();
-    }
-
-    if (d->delayedConsume)
-        consume(d->consumeOptions);
 }
 
 void QAmqpQueue::channelClosed()
 {
     Q_D(QAmqpQueue);
-    if (d->consuming)
+    if (d->consumerState == QAmqpQueuePrivate::C_CONSUMING)
         d->delayedConsume = true;
+    d->resetBindings();
 }
 
 int QAmqpQueue::options() const
@@ -343,11 +489,12 @@ void QAmqpQueue::declare(int options)
 void QAmqpQueue::remove(int options)
 {
     Q_D(QAmqpQueue);
-    if (!d->declared) {
+    if (d->queueState != QAmqpQueuePrivate::Q_DECLARED) {
         qAmqpDebug() << Q_FUNC_INFO << "trying to remove undeclared queue, aborting...";
         return;
     }
 
+    d->queueState = QAmqpQueuePrivate::Q_REMOVING;
     QAmqpMethodFrame frame(QAmqpFrame::Queue, QAmqpQueuePrivate::miDelete);
     frame.setChannel(d->channelNumber);
 
@@ -395,27 +542,19 @@ void QAmqpQueue::bind(QAmqpExchange *exchange, const QString &key)
 void QAmqpQueue::bind(const QString &exchangeName, const QString &key)
 {
     Q_D(QAmqpQueue);
-    if (d->channelState != QAmqpChannelPrivate::CH_OPEN) {
-        d->delayedBindings.append(QPair<QString,QString>(exchangeName, key));
+    QAmqpQueuePrivate::SubscriptionState& subState = d->getState(exchangeName);
+    subState.topicsToUnbind.remove(key);
+    if (subState.topics.contains(key)) {
+        qAmqpDebug() << Q_FUNC_INFO << "Already bound to exchange"
+                     << exchangeName << "topic" << key;
         return;
     }
 
-    QAmqpMethodFrame frame(QAmqpFrame::Queue, QAmqpQueuePrivate::miBind);
-    frame.setChannel(d->channelNumber);
+    subState.topicsToBind << key;
+    if (d->channelState != QAmqpChannelPrivate::CH_OPEN)
+        return;
 
-    QByteArray arguments;
-    QDataStream out(&arguments, QIODevice::WriteOnly);
-
-    out << qint16(0);   //  reserved 1
-    QAmqpFrame::writeAmqpField(out, QAmqpMetaType::ShortString, d->name);
-    QAmqpFrame::writeAmqpField(out, QAmqpMetaType::ShortString, exchangeName);
-    QAmqpFrame::writeAmqpField(out, QAmqpMetaType::ShortString, key);
-
-    out << qint8(0);    //  no-wait
-    QAmqpFrame::writeAmqpField(out, QAmqpMetaType::Hash, QAmqpTable());
-
-    frame.setArguments(arguments);
-    d->sendFrame(frame);
+    d->processBindings();
 }
 
 void QAmqpQueue::unbind(QAmqpExchange *exchange, const QString &key)
@@ -431,45 +570,55 @@ void QAmqpQueue::unbind(QAmqpExchange *exchange, const QString &key)
 void QAmqpQueue::unbind(const QString &exchangeName, const QString &key)
 {
     Q_D(QAmqpQueue);
-    if (d->channelState != QAmqpChannelPrivate::CH_OPEN) {
-        qAmqpDebug() << Q_FUNC_INFO << "queue is not open";
+    if (!d->bindings.contains(exchangeName)) {
+        qAmqpDebug() << Q_FUNC_INFO << "queue is not bound to "
+                                    << exchangeName;
         return;
     }
 
-    QAmqpMethodFrame frame(QAmqpFrame::Queue, QAmqpQueuePrivate::miUnbind);
-    frame.setChannel(d->channelNumber);
+    QAmqpQueuePrivate::SubscriptionState& subState = d->getState(exchangeName);
+    subState.topicsToBind.remove(key);
+    if (!subState.topics.contains(key)) {
+        qAmqpDebug() << Q_FUNC_INFO << "Not bound to exchange"
+                     << exchangeName << "topic" << key;
+        return;
+    }
 
-    QByteArray arguments;
-    QDataStream out(&arguments, QIODevice::WriteOnly);
-    out << qint16(0);   //reserved 1
-    QAmqpFrame::writeAmqpField(out, QAmqpMetaType::ShortString, d->name);
-    QAmqpFrame::writeAmqpField(out, QAmqpMetaType::ShortString, exchangeName);
-    QAmqpFrame::writeAmqpField(out, QAmqpMetaType::ShortString, key);
-    QAmqpFrame::writeAmqpField(out, QAmqpMetaType::Hash, QAmqpTable());
+    subState.topicsToUnbind << key;
+    if (d->channelState != QAmqpChannelPrivate::CH_OPEN)
+        return;
 
-    frame.setArguments(arguments);
-    d->sendFrame(frame);
+    d->processBindings();
 }
 
 bool QAmqpQueue::consume(int options)
 {
     Q_D(QAmqpQueue);
-    if (d->channelState != QAmqpChannelPrivate::CH_OPEN) {
+    if (d->queueState != QAmqpQueuePrivate::Q_DECLARED) {
         d->consumeOptions = options;
         d->delayedConsume = true;
         return true;
     }
 
-    if (d->consumeRequested) {
-        qAmqpDebug() << Q_FUNC_INFO << "already attempting to consume";
-        return false;
+    switch(d->consumerState) {
+        case QAmqpQueuePrivate::C_UNDECLARED:
+            d->consumeOptions = options;
+            d->delayedConsume = true;
+            return true;
+        case QAmqpQueuePrivate::C_REQUESTED:
+            qAmqpDebug() << Q_FUNC_INFO << "already attempting to consume";
+            return false;
+        case QAmqpQueuePrivate::C_CONSUMING:
+            qAmqpDebug() << Q_FUNC_INFO << "already consuming with tag: " << d->consumerTag;
+            return false;
+        case QAmqpQueuePrivate::C_CANCELLING:
+            qAmqpDebug() << Q_FUNC_INFO << "attempting to cancel";
+            return false;
+        default:
+            break;
     }
 
-    if (d->consuming) {
-        qAmqpDebug() << Q_FUNC_INFO << "already consuming with tag: " << d->consumerTag;
-        return false;
-    }
-
+    d->consumerState = QAmqpQueuePrivate::C_REQUESTED;
     QAmqpMethodFrame frame(QAmqpFrame::Basic, QAmqpQueuePrivate::bmConsume);
     frame.setChannel(d->channelNumber);
 
@@ -485,7 +634,6 @@ bool QAmqpQueue::consume(int options)
 
     frame.setArguments(arguments);
     d->sendFrame(frame);
-    d->consumeRequested = true;
     return true;
 }
 
@@ -504,19 +652,19 @@ QString QAmqpQueue::consumerTag() const
 bool QAmqpQueue::isConsuming() const
 {
     Q_D(const QAmqpQueue);
-    return d->consuming;
+    return d->consumerState == QAmqpQueuePrivate::C_CONSUMING;
 }
 
 bool QAmqpQueue::isDeclared() const
 {
     Q_D(const QAmqpQueue);
-    return d->declared;
+    return d->queueState == QAmqpQueuePrivate::Q_DECLARED;
 }
 
 void QAmqpQueue::get(bool noAck)
 {
     Q_D(QAmqpQueue);
-    if (d->channelState != QAmqpChannelPrivate::CH_OPEN) {
+    if (d->queueState != QAmqpQueuePrivate::Q_DECLARED) {
         qAmqpDebug() << Q_FUNC_INFO << "channel is not open";
         return;
     }
@@ -543,7 +691,7 @@ void QAmqpQueue::ack(const QAmqpMessage &message)
 void QAmqpQueue::ack(qlonglong deliveryTag, bool multiple)
 {
     Q_D(QAmqpQueue);
-    if (d->channelState != QAmqpChannelPrivate::CH_OPEN) {
+    if (d->queueState != QAmqpQueuePrivate::Q_DECLARED) {
         qAmqpDebug() << Q_FUNC_INFO << "channel is not open";
         return;
     }
@@ -569,7 +717,7 @@ void QAmqpQueue::reject(const QAmqpMessage &message, bool requeue)
 void QAmqpQueue::reject(qlonglong deliveryTag, bool requeue)
 {
     Q_D(QAmqpQueue);
-    if (d->channelState != QAmqpChannelPrivate::CH_OPEN) {
+    if (d->queueState != QAmqpQueuePrivate::Q_DECLARED) {
         qAmqpDebug() << Q_FUNC_INFO << "channel is not open";
         return;
     }
@@ -590,7 +738,8 @@ void QAmqpQueue::reject(qlonglong deliveryTag, bool requeue)
 bool QAmqpQueue::cancel(bool noWait)
 {
     Q_D(QAmqpQueue);
-    if (!d->consuming) {
+
+    if (d->consumerState != QAmqpQueuePrivate::C_CONSUMING) {
         qAmqpDebug() << Q_FUNC_INFO << "not consuming!";
         return false;
     }

--- a/src/qamqpqueue.cpp
+++ b/src/qamqpqueue.cpp
@@ -280,6 +280,7 @@ void QAmqpQueuePrivate::cancelOk(const QAmqpMethodFrame &frame)
     consumerTag.clear();
     consuming = false;
     consumeRequested = false;
+    delayedConsume = false;
     Q_EMIT q->cancelled(consumer);
 }
 
@@ -315,6 +316,9 @@ void QAmqpQueue::channelOpened()
 
 void QAmqpQueue::channelClosed()
 {
+    Q_D(QAmqpQueue);
+    if (d->consuming)
+        d->delayedConsume = true;
 }
 
 int QAmqpQueue::options() const

--- a/src/qamqpqueue.cpp
+++ b/src/qamqpqueue.cpp
@@ -16,7 +16,7 @@ QAmqpQueuePrivate::QAmqpQueuePrivate(QAmqpQueue *q)
     : QAmqpChannelPrivate(q),
       delayedDeclare(false),
       declared(false),
-      recievingMessage(false),
+      receivingMessage(false),
       consuming(false),
       consumeRequested(false)
 {

--- a/src/qamqpqueue.cpp
+++ b/src/qamqpqueue.cpp
@@ -138,8 +138,8 @@ void QAmqpQueuePrivate::declareOk(const QAmqpMethodFrame &frame)
 {
     Q_Q(QAmqpQueue);
     qAmqpDebug() << "declared queue: " << name;
-    queueState = Q_DECLARED;
-    consumerState = C_DECLARED;
+    newState(Q_DECLARED);
+    newState(C_DECLARED);
 
     QByteArray data = frame.arguments();
     QDataStream stream(&data, QIODevice::ReadOnly);
@@ -175,8 +175,8 @@ void QAmqpQueuePrivate::deleteOk(const QAmqpMethodFrame &frame)
 {
     Q_Q(QAmqpQueue);
     qAmqpDebug() << "deleted queue: " << name;
-    queueState = Q_UNDECLARED;
-    consumerState = C_UNDECLARED;
+    newState(Q_UNDECLARED);
+    newState(C_UNDECLARED);
 
     QByteArray data = frame.arguments();
     QDataStream stream(&data, QIODevice::ReadOnly);
@@ -257,7 +257,7 @@ void QAmqpQueuePrivate::consumeOk(const QAmqpMethodFrame &frame)
     QDataStream stream(&data, QIODevice::ReadOnly);
     consumerTag = QAmqpFrame::readAmqpField(stream, QAmqpMetaType::ShortString).toString();
     qAmqpDebug("consumer tag = %s", qPrintable(consumerTag));
-    consumerState = C_CONSUMING;
+    newState(C_CONSUMING);
     delayedConsume = false;
     processBindings();
     Q_EMIT q->consuming(consumerTag);
@@ -315,7 +315,7 @@ void QAmqpQueuePrivate::cancelOk(const QAmqpMethodFrame &frame)
     }
 
     consumerTag.clear();
-    consumerState = C_DECLARED;
+    newState(C_DECLARED);
     delayedConsume = false;
     Q_EMIT q->cancelled(consumer);
 }
@@ -438,6 +438,88 @@ void QAmqpQueuePrivate::processBindings()
     }
 }
 
+/*! Report and change state. */
+void QAmqpQueuePrivate::newState(QueueState state)
+{
+    qAmqpDebug() << "Queue"
+                 << name
+                 << "state:"
+                 << queueState
+                 << " -> "
+                 << state;
+    queueState = state;
+    if ((state == Q_CLOSED) || (state == Q_UNDECLARED))
+        newState(C_UNDECLARED);
+    else if (state == Q_DECLARED)
+        newState(C_DECLARED);
+}
+
+void QAmqpQueuePrivate::newState(ConsumerState state)
+{
+    qAmqpDebug() << "Consumer"
+                 << name
+                 << "state:"
+                 << consumerState
+                 << " -> "
+                 << state;
+    consumerState = state;
+}
+
+void QAmqpQueuePrivate::newState(ChannelState state)
+{
+    QAmqpChannelPrivate::newState(state);
+    if (state == QAmqpChannelPrivate::CH_CLOSED)
+        newState(Q_CLOSED);
+}
+
+QDebug operator<<(QDebug dbg, QAmqpQueuePrivate::QueueState s)
+{
+    switch(s) {
+        case QAmqpQueuePrivate::Q_CLOSED:
+            dbg << "Q_CLOSED";
+            break;
+        case QAmqpQueuePrivate::Q_UNDECLARED:
+            dbg << "Q_UNDECLARED";
+            break;
+        case QAmqpQueuePrivate::Q_DECLARING:
+            dbg << "Q_DECLARING";
+            break;
+        case QAmqpQueuePrivate::Q_DECLARED:
+            dbg << "Q_DECLARED";
+            break;
+        case QAmqpQueuePrivate::Q_REMOVING:
+            dbg << "Q_REMOVING";
+            break;
+        default:
+            dbg << "Q_????";
+    }
+    return dbg;
+}
+
+QDebug operator<<(QDebug dbg, QAmqpQueuePrivate::ConsumerState s)
+{
+    switch(s) {
+        case QAmqpQueuePrivate::C_UNDECLARED:
+            dbg << "C_UNDECLARED";
+            break;
+        case QAmqpQueuePrivate::C_DECLARED:
+            dbg << "C_DECLARED";
+            break;
+        case QAmqpQueuePrivate::C_REQUESTED:
+            dbg << "C_REQUESTED";
+            break;
+        case QAmqpQueuePrivate::C_CONSUMING:
+            dbg << "C_CONSUMING";
+            break;
+        case QAmqpQueuePrivate::C_CANCELLING:
+            dbg << "C_CANCELLING";
+            break;
+        default:
+            dbg << "C_????";
+    }
+    return dbg;
+}
+
 //////////////////////////////////////////////////////////////////////////
 
 QAmqpQueue::QAmqpQueue(int channelNumber, QAmqpClient *parent)
@@ -494,7 +576,7 @@ void QAmqpQueue::remove(int options)
         return;
     }
 
-    d->queueState = QAmqpQueuePrivate::Q_REMOVING;
+    d->newState(QAmqpQueuePrivate::Q_REMOVING);
     QAmqpMethodFrame frame(QAmqpFrame::Queue, QAmqpQueuePrivate::miDelete);
     frame.setChannel(d->channelNumber);
 
@@ -618,7 +700,7 @@ bool QAmqpQueue::consume(int options)
             break;
     }
 
-    d->consumerState = QAmqpQueuePrivate::C_REQUESTED;
+    d->newState(QAmqpQueuePrivate::C_REQUESTED);
     QAmqpMethodFrame frame(QAmqpFrame::Basic, QAmqpQueuePrivate::bmConsume);
     frame.setChannel(d->channelNumber);
 

--- a/src/qamqpqueue.cpp
+++ b/src/qamqpqueue.cpp
@@ -327,7 +327,7 @@ QAmqpQueuePrivate::SubscriptionState&
 QAmqpQueuePrivate::getState(const QString& exchangeName)
 {
     SubscriptionState& state = bindings[exchangeName];
-    if (state.exchange == NULL)
+    if (state.exchange.isNull())
         state.exchange = client->createExchange(exchangeName);
     return state;
 }

--- a/src/qamqpqueue.cpp
+++ b/src/qamqpqueue.cpp
@@ -464,12 +464,7 @@ void QAmqpQueuePrivate::_q_exchangeDeclared()
 /*! Report and change state. */
 void QAmqpQueuePrivate::newState(QueueState state)
 {
-    qAmqpDebug() << "Queue"
-                 << name
-                 << "state:"
-                 << queueState
-                 << " -> "
-                 << state;
+    qAmqpDebug() << "Queue" << name << "state:" << queueState << "->" << state;
     queueState = state;
     if ((state == QueueClosedState) || (state == QueueUndeclaredState))
         newState(ConsumerQueueUndeclaredState);
@@ -479,12 +474,7 @@ void QAmqpQueuePrivate::newState(QueueState state)
 
 void QAmqpQueuePrivate::newState(ConsumerState state)
 {
-    qAmqpDebug() << "Consumer"
-                 << name
-                 << "state:"
-                 << consumerState
-                 << " -> "
-                 << state;
+    qAmqpDebug() << "Consumer" << name << "state:" << consumerState << "->" << state;
     consumerState = state;
 }
 

--- a/src/qamqpqueue.cpp
+++ b/src/qamqpqueue.cpp
@@ -322,7 +322,7 @@ void QAmqpQueue::declare(int options)
     Q_D(QAmqpQueue);
     d->options = options;
 
-    if (!d->opened) {
+    if (d->channelState != QAmqpChannelPrivate::CH_OPEN) {
         d->delayedDeclare = true;
         return;
     }
@@ -356,7 +356,7 @@ void QAmqpQueue::purge()
 {
     Q_D(QAmqpQueue);
 
-    if (!d->opened)
+    if (d->channelState != QAmqpChannelPrivate::CH_OPEN)
         return;
 
     QAmqpMethodFrame frame(QAmqpFrame::Queue, QAmqpQueuePrivate::miPurge);
@@ -385,7 +385,7 @@ void QAmqpQueue::bind(QAmqpExchange *exchange, const QString &key)
 void QAmqpQueue::bind(const QString &exchangeName, const QString &key)
 {
     Q_D(QAmqpQueue);
-    if (!d->opened) {
+    if (d->channelState != QAmqpChannelPrivate::CH_OPEN) {
         d->delayedBindings.append(QPair<QString,QString>(exchangeName, key));
         return;
     }
@@ -421,7 +421,7 @@ void QAmqpQueue::unbind(QAmqpExchange *exchange, const QString &key)
 void QAmqpQueue::unbind(const QString &exchangeName, const QString &key)
 {
     Q_D(QAmqpQueue);
-    if (!d->opened) {
+    if (d->channelState != QAmqpChannelPrivate::CH_OPEN) {
         qAmqpDebug() << Q_FUNC_INFO << "queue is not open";
         return;
     }
@@ -444,7 +444,7 @@ void QAmqpQueue::unbind(const QString &exchangeName, const QString &key)
 bool QAmqpQueue::consume(int options)
 {
     Q_D(QAmqpQueue);
-    if (!d->opened) {
+    if (d->channelState != QAmqpChannelPrivate::CH_OPEN) {
         qAmqpDebug() << Q_FUNC_INFO << "queue is not open";
         return false;
     }
@@ -505,7 +505,7 @@ bool QAmqpQueue::isDeclared() const
 void QAmqpQueue::get(bool noAck)
 {
     Q_D(QAmqpQueue);
-    if (!d->opened) {
+    if (d->channelState != QAmqpChannelPrivate::CH_OPEN) {
         qAmqpDebug() << Q_FUNC_INFO << "channel is not open";
         return;
     }
@@ -532,7 +532,7 @@ void QAmqpQueue::ack(const QAmqpMessage &message)
 void QAmqpQueue::ack(qlonglong deliveryTag, bool multiple)
 {
     Q_D(QAmqpQueue);
-    if (!d->opened) {
+    if (d->channelState != QAmqpChannelPrivate::CH_OPEN) {
         qAmqpDebug() << Q_FUNC_INFO << "channel is not open";
         return;
     }
@@ -558,7 +558,7 @@ void QAmqpQueue::reject(const QAmqpMessage &message, bool requeue)
 void QAmqpQueue::reject(qlonglong deliveryTag, bool requeue)
 {
     Q_D(QAmqpQueue);
-    if (!d->opened) {
+    if (d->channelState != QAmqpChannelPrivate::CH_OPEN) {
         qAmqpDebug() << Q_FUNC_INFO << "channel is not open";
         return;
     }

--- a/src/qamqpqueue.cpp
+++ b/src/qamqpqueue.cpp
@@ -498,23 +498,23 @@ void QAmqpQueuePrivate::newState(ChannelState state)
 QDebug operator<<(QDebug dbg, QAmqpQueuePrivate::QueueState s)
 {
     switch(s) {
-        case QAmqpQueuePrivate::QueueClosedState:
-            dbg << "QueueClosedState";
-            break;
-        case QAmqpQueuePrivate::QueueUndeclaredState:
-            dbg << "QueueUndeclaredState";
-            break;
-        case QAmqpQueuePrivate::QueueDeclaringState:
-            dbg << "QueueDeclaredState";
-            break;
-        case QAmqpQueuePrivate::QueueDeclaredState:
-            dbg << "QueueDeclaredState";
-            break;
-        case QAmqpQueuePrivate::QueueRemovingState:
-            dbg << "QueueRemovingState";
-            break;
-        default:
-            dbg << "{UNKNOWN QUEUE STATE}";
+    case QAmqpQueuePrivate::QueueClosedState:
+        dbg << "QueueClosedState";
+        break;
+    case QAmqpQueuePrivate::QueueUndeclaredState:
+        dbg << "QueueUndeclaredState";
+        break;
+    case QAmqpQueuePrivate::QueueDeclaringState:
+        dbg << "QueueDeclaredState";
+        break;
+    case QAmqpQueuePrivate::QueueDeclaredState:
+        dbg << "QueueDeclaredState";
+        break;
+    case QAmqpQueuePrivate::QueueRemovingState:
+        dbg << "QueueRemovingState";
+        break;
+    default:
+        dbg << "{UNKNOWN QUEUE STATE}";
     }
     return dbg;
 }
@@ -522,23 +522,23 @@ QDebug operator<<(QDebug dbg, QAmqpQueuePrivate::QueueState s)
 QDebug operator<<(QDebug dbg, QAmqpQueuePrivate::ConsumerState s)
 {
     switch(s) {
-        case QAmqpQueuePrivate::ConsumerQueueUndeclaredState:
-            dbg << "ConsumerQueueUndeclaredState";
-            break;
-        case QAmqpQueuePrivate::ConsumerQueueDeclaredState:
-            dbg << "ConsumerQueueDeclaredState";
-            break;
-        case QAmqpQueuePrivate::ConsumerRequestedState:
-            dbg << "ConsumerRequestedState";
-            break;
-        case QAmqpQueuePrivate::ConsumerConsumingState:
-            dbg << "ConsumerConsumingState";
-            break;
-        case QAmqpQueuePrivate::ConsumerCancellingState:
-            dbg << "ConsumerCancellingState";
-            break;
-        default:
-            dbg << "{UNKNOWN CONSUMER STATE}";
+    case QAmqpQueuePrivate::ConsumerQueueUndeclaredState:
+        dbg << "ConsumerQueueUndeclaredState";
+        break;
+    case QAmqpQueuePrivate::ConsumerQueueDeclaredState:
+        dbg << "ConsumerQueueDeclaredState";
+        break;
+    case QAmqpQueuePrivate::ConsumerRequestedState:
+        dbg << "ConsumerRequestedState";
+        break;
+    case QAmqpQueuePrivate::ConsumerConsumingState:
+        dbg << "ConsumerConsumingState";
+        break;
+    case QAmqpQueuePrivate::ConsumerCancellingState:
+        dbg << "ConsumerCancellingState";
+        break;
+    default:
+        dbg << "{UNKNOWN CONSUMER STATE}";
     }
     return dbg;
 }
@@ -711,21 +711,21 @@ bool QAmqpQueue::consume(int options)
     }
 
     switch(d->consumerState) {
-        case QAmqpQueuePrivate::ConsumerQueueUndeclaredState:
-            d->consumeOptions = options;
-            d->delayedConsume = true;
-            return true;
-        case QAmqpQueuePrivate::ConsumerRequestedState:
-            qAmqpDebug() << Q_FUNC_INFO << "already attempting to consume";
-            return false;
-        case QAmqpQueuePrivate::ConsumerConsumingState:
-            qAmqpDebug() << Q_FUNC_INFO << "already consuming with tag: " << d->consumerTag;
-            return false;
-        case QAmqpQueuePrivate::ConsumerCancellingState:
-            qAmqpDebug() << Q_FUNC_INFO << "attempting to cancel";
-            return false;
-        default:
-            break;
+    case QAmqpQueuePrivate::ConsumerQueueUndeclaredState:
+        d->consumeOptions = options;
+        d->delayedConsume = true;
+        return true;
+    case QAmqpQueuePrivate::ConsumerRequestedState:
+        qAmqpDebug() << Q_FUNC_INFO << "already attempting to consume";
+        return false;
+    case QAmqpQueuePrivate::ConsumerConsumingState:
+        qAmqpDebug() << Q_FUNC_INFO << "already consuming with tag: " << d->consumerTag;
+        return false;
+    case QAmqpQueuePrivate::ConsumerCancellingState:
+        qAmqpDebug() << Q_FUNC_INFO << "attempting to cancel";
+        return false;
+    default:
+        break;
     }
 
     d->newState(QAmqpQueuePrivate::ConsumerRequestedState);

--- a/src/qamqpqueue.h
+++ b/src/qamqpqueue.h
@@ -116,6 +116,8 @@ private:
     Q_DISABLE_COPY(QAmqpQueue)
     Q_DECLARE_PRIVATE(QAmqpQueue)
 
+    Q_PRIVATE_SLOT(d_func(), void _q_exchangeDeclared())
+
     friend class QAmqpClient;
 };
 

--- a/src/qamqpqueue_p.h
+++ b/src/qamqpqueue_p.h
@@ -40,28 +40,28 @@ public:
 
     enum QueueState {
         /*! Channel is closed */
-        Q_CLOSED,
+        QueueClosedState,
         /*! Queue is undeclared */
-        Q_UNDECLARED,
+        QueueUndeclaredState,
         /*! Queue is declaring */
-        Q_DECLARING,
+        QueueDeclaringState,
         /*! Queue is declared */
-        Q_DECLARED,
+        QueueDeclaredState,
         /*! Queue is being removed */
-        Q_REMOVING,
+        QueueRemovingState,
     };
 
     enum ConsumerState {
         /*! Queue is undeclared */
-        C_UNDECLARED,
+        ConsumerQueueUndeclaredState,
         /*! Queue is declared */
-        C_DECLARED,
+        ConsumerQueueDeclaredState,
         /*! Consumation request started */
-        C_REQUESTED,
+        ConsumerRequestedState,
         /*! Consumation in progress */
-        C_CONSUMING,
+        ConsumerConsumingState,
         /*! Cancellation in progress */
-        C_CANCELLING,
+        ConsumerCancellingState,
     };
 
     QAmqpQueuePrivate(QAmqpQueue *q);

--- a/src/qamqpqueue_p.h
+++ b/src/qamqpqueue_p.h
@@ -4,6 +4,7 @@
 #include <QQueue>
 #include <QSet>
 #include <QHash>
+#include <QPointer>
 #include <QStringList>
 
 #include "qamqpchannel_p.h"
@@ -28,7 +29,7 @@ public:
     class SubscriptionState {
     public:
         /*! Exchange pointer, for checking state */
-        QAmqpExchange*  exchange;
+        QPointer<QAmqpExchange> exchange;
         /*! Presently subscribed topics */
         QSet<QString>   topics;
         /*! Topics that are to be bound */

--- a/src/qamqpqueue_p.h
+++ b/src/qamqpqueue_p.h
@@ -117,6 +117,11 @@ public:
      */
     void processBindings();
 
+    /*! Report and change state. */
+    virtual void newState(ChannelState state);
+    virtual void newState(QueueState state);
+    virtual void newState(ConsumerState state);
+
     QString consumerTag;
     bool receivingMessage;
     QAmqpMessage currentMessage;
@@ -127,5 +132,8 @@ public:
     Q_DECLARE_PUBLIC(QAmqpQueue)
 
 };
+
+QDebug operator<<(QDebug dbg, QAmqpQueuePrivate::QueueState s);
+QDebug operator<<(QDebug dbg, QAmqpQueuePrivate::ConsumerState s);
 
 #endif // QAMQPQUEUE_P_H

--- a/src/qamqpqueue_p.h
+++ b/src/qamqpqueue_p.h
@@ -49,7 +49,9 @@ public:
     QString consumerTag;
     bool receivingMessage;
     QAmqpMessage currentMessage;
+    int consumeOptions;
     bool consuming;
+    bool delayedConsume;
     bool consumeRequested;
 
     Q_DECLARE_PUBLIC(QAmqpQueue)

--- a/src/qamqpqueue_p.h
+++ b/src/qamqpqueue_p.h
@@ -85,6 +85,11 @@ public:
     void getOk(const QAmqpMethodFrame &frame);
     void cancelOk(const QAmqpMethodFrame &frame);
 
+    // Private slots
+
+    /*! Process delayed bindings for a given exchange. */
+    void _q_exchangeDeclared();
+
     QString type;
     int options;
     bool delayedDeclare;
@@ -103,7 +108,8 @@ public:
     /*!
      * Retrieve the state of an exchange's bindings.
      */
-    SubscriptionState& getState(const QString& exchangeName);
+    SubscriptionState& getState(const QString& exchangeName,
+		    QAmqpExchange* exchange=0);
 
     /*!
      * Reset the binding state.  This marks all presently "subscribed" exchanges

--- a/src/qamqpqueue_p.h
+++ b/src/qamqpqueue_p.h
@@ -47,7 +47,7 @@ public:
     QQueue<QPair<QString, QString> > delayedBindings;
 
     QString consumerTag;
-    bool recievingMessage;
+    bool receivingMessage;
     QAmqpMessage currentMessage;
     bool consuming;
     bool consumeRequested;

--- a/src/src.pro
+++ b/src/src.pro
@@ -33,6 +33,7 @@ greaterThan(NEED_GCOV_SUPPORT, 0) {
 
 PRIVATE_HEADERS += \
     qamqpchannel_p.h \
+    qamqpchannelhash_p.h \
     qamqpclient_p.h \
     qamqpexchange_p.h \
     qamqpframe_p.h \
@@ -56,6 +57,7 @@ HEADERS += \
 SOURCES += \
     qamqpauthenticator.cpp \
     qamqpchannel.cpp \
+    qamqpchannelhash.cpp \
     qamqpclient.cpp \
     qamqpexchange.cpp \
     qamqpframe.cpp \

--- a/tests/auto/qamqpexchange/tst_qamqpexchange.cpp
+++ b/tests/auto/qamqpexchange/tst_qamqpexchange.cpp
@@ -209,6 +209,7 @@ void tst_QAMQPExchange::cleanupOnDeletion()
     QVERIFY(waitForSignal(exchange, SIGNAL(declared())));
     exchange->close();
     exchange->deleteLater();
+    QVERIFY(waitForSignal(exchange, SIGNAL(destroyed())));
 
     // now create, declare, and close the right way
     exchange = client->createExchange("test-deletion");

--- a/tests/auto/qamqpqueue/tst_qamqpqueue.cpp
+++ b/tests/auto/qamqpqueue/tst_qamqpqueue.cpp
@@ -683,6 +683,7 @@ void tst_QAMQPQueue::cleanupOnDeletion()
     QVERIFY(waitForSignal(queue, SIGNAL(declared())));
     queue->close();
     queue->deleteLater();
+    QVERIFY(waitForSignal(queue, SIGNAL(destroyed())));
 
     // now create, declare, and close the right way
     queue = client->createQueue("test-deletion");


### PR DESCRIPTION
This uses crude state machines (use of QStateMachine is on the road map) to implement various operations for Queues and Exchanges.

If the connection gets dropped or a channel forcibly closed, this allows the exchange or queue to restore its state when the channel re-opens, including binding to exchanges/topics in the case of queues.  It also allows for set-and-forget configuration of exchanges and queues, since the state machine will take care to ensure the steps are done at the appropriate times.

Status of this branch:
- Code mostly seems to do what it says on the tin (172 exchanges, 59 queues) but more testing needed.
- Some tests probably need reviewing
- Coding style in this branch will need checking, I'll work on this as I come across coding style violations.