### PR TITLE
Add storage of Queues and Exchanges to QAmqpClient.

### DIFF
--- a/src/qamqpchannel.cpp
+++ b/src/qamqpchannel.cpp
@@ -203,9 +203,17 @@ void QAmqpChannelPrivate::close(const QAmqpMethodFrame &frame)
     QAmqpMethodFrame closeOkFrame(QAmqpFrame::Channel, miCloseOk);
     closeOkFrame.setChannel(channelNumber);
     sendFrame(closeOkFrame);
+
+    // notify everyone that the channel was closed on us.
+    notifyClosed();
 }
 
 void QAmqpChannelPrivate::closeOk(const QAmqpMethodFrame &)
+{
+    notifyClosed();
+}
+
+void QAmqpChannelPrivate::notifyClosed()
 {
     Q_Q(QAmqpChannel);
     Q_EMIT q->closed();

--- a/src/qamqpchannel_p.h
+++ b/src/qamqpchannel_p.h
@@ -44,6 +44,7 @@ public:
     void flow(bool active);
     void flowOk();
     void close(int code, const QString &text, int classId, int methodId);
+    void notifyClosed();
 
     // reimp MethodHandler
     virtual bool _q_method(const QAmqpMethodFrame &frame);

--- a/src/qamqpchannelhash.cpp
+++ b/src/qamqpchannelhash.cpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2012-2014 Alexey Shcherbakov
+ * Copyright (C) 2014-2015 Matt Broadstone
+ * Contact: https://github.com/mbroadst/qamqp
+ *
+ * This file is part of the QAMQP Library.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ */
+#include "qamqpqueue.h"
+#include "qamqpexchange.h"
+#include "qamqpchannelhash_p.h"
+
+/*!
+* Retrieve a pointer to the named channel.
+*
+* A NULL string is assumed to be equivalent to "" for the purpose
+* of retrieving the nameless (default) exchange.
+*
+* \param[in]   name    The name of the channel to retrieve.
+* \retval      NULL    Channel does not exist.
+*/
+QAmqpChannel* QAmqpChannelHash::get(const QString& name) const
+{
+    if (name.isNull())
+        return channels.value(QString(""));
+    return channels.value(name);
+}
+
+/*!
+* Store an exchange in the hash.  The nameless exchange is stored under
+* the name "".
+*/
+void QAmqpChannelHash::put(QAmqpExchange* exchange)
+{
+    if (exchange->name().isEmpty())
+        put(QString(""), exchange);
+    else
+        put(exchange->name(), exchange);
+}
+
+/*!
+* Store a queue in the hash.  If the queue is nameless, we hook its
+* declared signal and store it when the queue receives a name from the
+* broker, otherwise we store it under the name given.
+*/
+void QAmqpChannelHash::put(QAmqpQueue* queue)
+{
+    if (queue->name().isEmpty())
+        connect(queue,  SIGNAL(declared()),
+                this,   SLOT(queueDeclared()));
+    else
+        put(queue->name(), queue);
+}
+
+/*!
+* Handle destruction of a channel.  Retrieve its current name and
+* remove it from the list, otherwise do a full garbage collection
+* run.
+*/
+void QAmqpChannelHash::channelDestroyed()
+{
+    QAmqpChannel* ch = static_cast<QAmqpChannel*>(sender());
+    if (!channels.contains(ch->name()))
+        return;
+    if (channels[ch->name()] == ch)
+        channels.remove(ch->name());
+}
+
+/*!
+* Handle a queue that has just been declared and given a new name.  The
+* caller is assumed to be a QAmqpQueue instance.
+*/
+void QAmqpChannelHash::queueDeclared()
+{
+    put(static_cast<QAmqpQueue*>(sender()));
+}
+
+/*!
+* Store a channel in the hash.  The channel is assumed
+* to be named at the time of storage.  This hooks the 'destroyed' signal
+* so the channel can be removed from our list.
+*/
+void QAmqpChannelHash::put(const QString& name, QAmqpChannel* channel)
+{
+    connect(channel,    SIGNAL(destroyed()),
+            this,       SLOT(channelDestroyed()));
+    channels[name] = channel;
+}
+
+#include "moc_qamqpchannelhash_p.cpp"
+/* vim: set ts=4 sw=4 et */

--- a/src/qamqpchannelhash.cpp
+++ b/src/qamqpchannelhash.cpp
@@ -90,7 +90,9 @@ void QAmqpChannelHash::channelDestroyed(QObject* object)
 */
 void QAmqpChannelHash::queueDeclared()
 {
-    put(static_cast<QAmqpQueue*>(sender()));
+    QAmqpQueue *queue = qobject_cast<QAmqpQueue*>(sender());
+    if (queue)
+        put(queue);
 }
 
 /*!

--- a/src/qamqpchannelhash.cpp
+++ b/src/qamqpchannelhash.cpp
@@ -30,8 +30,8 @@
 */
 QAmqpChannel* QAmqpChannelHash::get(const QString& name) const
 {
-    if (name.isNull())
-        return channels.value(QString(""));
+    if (name.isEmpty())
+        return channels.value(QString());
     return channels.value(name);
 }
 
@@ -41,8 +41,8 @@ QAmqpChannel* QAmqpChannelHash::get(const QString& name) const
 */
 bool QAmqpChannelHash::contains(const QString& name) const
 {
-    if (name.isNull())
-        return channels.contains(QString(""));
+    if (name.isEmpty())
+        return channels.contains(QString());
     return channels.contains(name);
 }
 
@@ -53,7 +53,7 @@ bool QAmqpChannelHash::contains(const QString& name) const
 void QAmqpChannelHash::put(QAmqpExchange* exchange)
 {
     if (exchange->name().isEmpty())
-        put(QString(""), exchange);
+        put(QString(), exchange);
     else
         put(exchange->name(), exchange);
 }

--- a/src/qamqpchannelhash.cpp
+++ b/src/qamqpchannelhash.cpp
@@ -62,17 +62,16 @@ void QAmqpChannelHash::put(QAmqpQueue* queue)
 }
 
 /*!
-* Handle destruction of a channel.  Retrieve its current name and
-* remove it from the list, otherwise do a full garbage collection
-* run.
+* Handle destruction of a channel.  Do a full garbage collection run.
 */
-void QAmqpChannelHash::channelDestroyed()
+void QAmqpChannelHash::channelDestroyed(QObject* object)
 {
-    QAmqpChannel* ch = static_cast<QAmqpChannel*>(sender());
-    if (!channels.contains(ch->name()))
-        return;
-    if (channels[ch->name()] == ch)
-        channels.remove(ch->name());
+    QList<QString> names(channels.keys());
+    QList<QString>::iterator it;
+    for (it = names.begin(); it != names.end(); it++) {
+        if (channels.value(*it) == object)
+            channels.remove(*it);
+    }
 }
 
 /*!
@@ -91,8 +90,8 @@ void QAmqpChannelHash::queueDeclared()
 */
 void QAmqpChannelHash::put(const QString& name, QAmqpChannel* channel)
 {
-    connect(channel,    SIGNAL(destroyed()),
-            this,       SLOT(channelDestroyed()));
+    connect(channel,    SIGNAL(destroyed(QObject*)),
+            this,       SLOT(channelDestroyed(QObject*)));
     channels[name] = channel;
 }
 

--- a/src/qamqpchannelhash.cpp
+++ b/src/qamqpchannelhash.cpp
@@ -55,8 +55,7 @@ void QAmqpChannelHash::put(QAmqpExchange* exchange)
 void QAmqpChannelHash::put(QAmqpQueue* queue)
 {
     if (queue->name().isEmpty())
-        connect(queue,  SIGNAL(declared()),
-                this,   SLOT(queueDeclared()));
+        connect(queue, SIGNAL(declared()), this, SLOT(queueDeclared()));
     else
         put(queue->name(), queue);
 }
@@ -90,8 +89,7 @@ void QAmqpChannelHash::queueDeclared()
 */
 void QAmqpChannelHash::put(const QString& name, QAmqpChannel* channel)
 {
-    connect(channel,    SIGNAL(destroyed(QObject*)),
-            this,       SLOT(channelDestroyed(QObject*)));
+    connect(channel, SIGNAL(destroyed(QObject*)), this, SLOT(channelDestroyed(QObject*)));
     channels[name] = channel;
 }
 

--- a/src/qamqpchannelhash.cpp
+++ b/src/qamqpchannelhash.cpp
@@ -35,6 +35,17 @@ QAmqpChannel* QAmqpChannelHash::get(const QString& name) const
     return channels.value(name);
 }
 
+
+/*!
+* Return true if the named channel exists.
+*/
+bool QAmqpChannelHash::contains(const QString& name) const
+{
+    if (name.isNull())
+        return channels.contains(QString(""));
+    return channels.contains(name);
+}
+
 /*!
 * Store an exchange in the hash.  The nameless exchange is stored under
 * the name "".

--- a/src/qamqpchannelhash_p.h
+++ b/src/qamqpchannelhash_p.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2012-2014 Alexey Shcherbakov
+ * Copyright (C) 2014-2015 Matt Broadstone
+ * Contact: https://github.com/mbroadst/qamqp
+ *
+ * This file is part of the QAMQP Library.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ */
+#ifndef QAMQPCHANNELHASH_P_H
+#define QAMQPCHANNELHASH_P_H
+
+#include <QHash>
+#include <QString>
+#include <QObject>
+
+/* Forward declarations */
+class QAmqpChannel;
+class QAmqpQueue;
+class QAmqpExchange;
+
+/*!
+ * QAmqpChannelHash is a container for storing queues and exchanges for later
+ * retrieval.  When the objects are destroyed, they are automatically removed
+ * from the container.
+ */
+class QAmqpChannelHash : public QObject
+{
+    Q_OBJECT
+public:
+    /*!
+     * Retrieve a pointer to the named channel.
+     *
+     * A NULL string is assumed to be equivalent to "" for the purpose
+     * of retrieving the nameless (default) exchange.
+     *
+     * \param[in]   name    The name of the channel to retrieve.
+     * \retval      NULL    Channel does not exist.
+     */
+    QAmqpChannel* get(const QString& name) const;
+
+    /*!
+     * Store an exchange in the hash.  The nameless exchange is stored under
+     * the name "".
+     */
+    void put(QAmqpExchange* exchange);
+
+    /*!
+     * Store a queue in the hash.  If the queue is nameless, we hook its
+     * declared signal and store it when the queue receives a name from the
+     * broker, otherwise we store it under the name given.
+     */
+    void put(QAmqpQueue* queue);
+
+private Q_SLOTS:
+    /*!
+     * Handle destruction of a channel.  Retrieve its current name and
+     * remove it from the list, otherwise do a full garbage collection
+     * run.
+     */
+    void channelDestroyed();
+
+    /*!
+     * Handle a queue that has just been declared and given a new name.  The
+     * caller is assumed to be a QAmqpQueue instance.
+     */
+    void queueDeclared();
+
+private:
+    /*!
+     * Store a channel in the hash.  This hooks the 'destroyed' signal
+     * so the channel can be removed from our list.
+     */
+    void put(const QString& name, QAmqpChannel* channel);
+
+    /*! A collection of channels.  Key is the channel's "name". */
+    QHash<QString, QAmqpChannel*> channels;
+};
+
+/* vim: set ts=4 sw=4 et */
+#endif

--- a/src/qamqpchannelhash_p.h
+++ b/src/qamqpchannelhash_p.h
@@ -48,6 +48,11 @@ public:
     QAmqpChannel* get(const QString& name) const;
 
     /*!
+     * Return true if the named channel exists.
+     */
+    bool contains(const QString& name) const;
+
+    /*!
      * Store an exchange in the hash.  The nameless exchange is stored under
      * the name "".
      */

--- a/src/qamqpchannelhash_p.h
+++ b/src/qamqpchannelhash_p.h
@@ -62,11 +62,9 @@ public:
 
 private Q_SLOTS:
     /*!
-     * Handle destruction of a channel.  Retrieve its current name and
-     * remove it from the list, otherwise do a full garbage collection
-     * run.
+     * Handle destruction of a channel.  Do a full garbage collection run.
      */
-    void channelDestroyed();
+    void channelDestroyed(QObject* object);
 
     /*!
      * Handle a queue that has just been declared and given a new name.  The

--- a/src/qamqpclient.cpp
+++ b/src/qamqpclient.cpp
@@ -660,9 +660,9 @@ QAmqpExchange *QAmqpClient::createExchange(int channelNumber)
 QAmqpExchange *QAmqpClient::createExchange(const QString &name, int channelNumber)
 {
     Q_D(QAmqpClient);
-    QAmqpExchange *exchange = static_cast<QAmqpExchange*>(d->exchanges.get(name));
-    if (exchange != NULL)
-        return exchange;
+    QAmqpExchange *exchange;
+    if (d->exchanges.contains(name))
+	return static_cast<QAmqpExchange*>(d->exchanges.get(name));
 
     exchange = new QAmqpExchange(channelNumber, this);
     d->methodHandlersByChannel[exchange->channelNumber()].append(exchange->d_func());
@@ -684,9 +684,9 @@ QAmqpQueue *QAmqpClient::createQueue(int channelNumber)
 QAmqpQueue *QAmqpClient::createQueue(const QString &name, int channelNumber)
 {
     Q_D(QAmqpClient);
-    QAmqpQueue *queue = static_cast<QAmqpQueue*>(d->queues.get(name));
-    if (queue != NULL)
-        return queue;
+    QAmqpQueue *queue;
+    if (d->queues.contains(name))
+        return static_cast<QAmqpQueue*>(d->queues.get(name));
 
     queue = new QAmqpQueue(channelNumber, this);
     d->methodHandlersByChannel[queue->channelNumber()].append(queue->d_func());

--- a/src/qamqpclient.cpp
+++ b/src/qamqpclient.cpp
@@ -672,15 +672,16 @@ QAmqpExchange *QAmqpClient::createExchange(const QString &name, int channelNumbe
 
     if (!name.isEmpty())
         exchange->setName(name);
-    else if (name.isNull())
+    if (name.isNull())
         /*
          * We don't want two copies of the default exchange, one referenced by
          * QString() and the other by QString("").  QString() != QString("")  So
          * if it's null, overwrite with the empty string, since that's its
          * official name.
          */
-        name = "";
-    d->exchanges[name] = exchange;
+        d->exchanges[""] = exchange;
+    else
+        d->exchanges[name] = exchange;
     return exchange;
 }
 

--- a/src/qamqpclient.cpp
+++ b/src/qamqpclient.cpp
@@ -661,8 +661,11 @@ QAmqpExchange *QAmqpClient::createExchange(const QString &name, int channelNumbe
 {
     Q_D(QAmqpClient);
     QAmqpExchange *exchange;
-    if (d->exchanges.contains(name))
-	return static_cast<QAmqpExchange*>(d->exchanges.get(name));
+    if (d->exchanges.contains(name)) {
+        exchange = qobject_cast<QAmqpExchange*>(d->exchanges.get(name));
+        if (exchange)
+            return exchange;
+    }
 
     exchange = new QAmqpExchange(channelNumber, this);
     d->methodHandlersByChannel[exchange->channelNumber()].append(exchange->d_func());
@@ -685,8 +688,11 @@ QAmqpQueue *QAmqpClient::createQueue(const QString &name, int channelNumber)
 {
     Q_D(QAmqpClient);
     QAmqpQueue *queue;
-    if (d->queues.contains(name))
-        return static_cast<QAmqpQueue*>(d->queues.get(name));
+    if (d->queues.contains(name)) {
+        queue = qobject_cast<QAmqpQueue*>(d->queues.get(name));
+        if (queue)
+            return queue;
+    }
 
     queue = new QAmqpQueue(channelNumber, this);
     d->methodHandlersByChannel[queue->channelNumber()].append(queue->d_func());

--- a/src/qamqpclient.cpp
+++ b/src/qamqpclient.cpp
@@ -670,10 +670,17 @@ QAmqpExchange *QAmqpClient::createExchange(const QString &name, int channelNumbe
     connect(this, SIGNAL(disconnected()), exchange, SLOT(_q_disconnected()));
     exchange->d_func()->open();
 
-    if (!name.isEmpty()) {
+    if (!name.isEmpty())
         exchange->setName(name);
-        d->exchanges[name] = exchange;
-    }
+    else if (name.isNull())
+        /*
+         * We don't want two copies of the default exchange, one referenced by
+         * QString() and the other by QString("").  QString() != QString("")  So
+         * if it's null, overwrite with the empty string, since that's its
+         * official name.
+         */
+        name = "";
+    d->exchanges[name] = exchange;
     return exchange;
 }
 

--- a/src/qamqpclient.cpp
+++ b/src/qamqpclient.cpp
@@ -660,14 +660,19 @@ QAmqpExchange *QAmqpClient::createExchange(int channelNumber)
 QAmqpExchange *QAmqpClient::createExchange(const QString &name, int channelNumber)
 {
     Q_D(QAmqpClient);
+    if (!name.isEmpty() && d->exchanges.contains(name))
+        return d->exchanges[name];
+
     QAmqpExchange *exchange = new QAmqpExchange(channelNumber, this);
     d->methodHandlersByChannel[exchange->channelNumber()].append(exchange->d_func());
     connect(this, SIGNAL(connected()), exchange, SLOT(_q_open()));
     connect(this, SIGNAL(disconnected()), exchange, SLOT(_q_disconnected()));
     exchange->d_func()->open();
 
-    if (!name.isEmpty())
+    if (!name.isEmpty()) {
         exchange->setName(name);
+        d->exchanges[name] = exchange;
+    }
     return exchange;
 }
 
@@ -679,6 +684,9 @@ QAmqpQueue *QAmqpClient::createQueue(int channelNumber)
 QAmqpQueue *QAmqpClient::createQueue(const QString &name, int channelNumber)
 {
     Q_D(QAmqpClient);
+    if (!name.isEmpty() && d->queues.contains(name))
+        return d->queues[name];
+
     QAmqpQueue *queue = new QAmqpQueue(channelNumber, this);
     d->methodHandlersByChannel[queue->channelNumber()].append(queue->d_func());
     d->contentHandlerByChannel[queue->channelNumber()].append(queue->d_func());
@@ -687,8 +695,10 @@ QAmqpQueue *QAmqpClient::createQueue(const QString &name, int channelNumber)
     connect(this, SIGNAL(disconnected()), queue, SLOT(_q_disconnected()));
     queue->d_func()->open();
 
-    if (!name.isEmpty())
+    if (!name.isEmpty()) {
         queue->setName(name);
+        d->queues[name] = queue;
+    }
     return queue;
 }
 

--- a/src/qamqpclient.cpp
+++ b/src/qamqpclient.cpp
@@ -560,14 +560,14 @@ void QAmqpClientPrivate::_q_objectDestroyed()
     QHash<QString, QPointer<QAmqpExchange> > exchanges(this->exchanges);
     QHash<QString, QPointer<QAmqpExchange> >::iterator ex_it;
     for (ex_it = exchanges.begin() ; ex_it != exchanges.end(); ex_it++)
-        if (ex_it.value.isNull())
+        if (ex_it.value().isNull())
             this->exchanges.remove(ex_it.key());
 
     /* Clean up Queues */
     QHash<QString, QPointer<QAmqpQueue> > queues(this->queues);
     QHash<QString, QPointer<QAmqpQueue> >::iterator q_it;
     for (q_it = queues.begin() ; q_it != queues.end(); q_it++)
-        if (q_it.value.isNull())
+        if (q_it.value().isNull())
             this->queues.remove(q_it.key());
 }
 

--- a/src/qamqpclient.cpp
+++ b/src/qamqpclient.cpp
@@ -660,8 +660,9 @@ QAmqpExchange *QAmqpClient::createExchange(int channelNumber)
 QAmqpExchange *QAmqpClient::createExchange(const QString &name, int channelNumber)
 {
     Q_D(QAmqpClient);
-    if (!name.isEmpty() && d->exchanges.contains(name))
-        return d->exchanges[name];
+    if (!name.isEmpty() && d->exchanges.contains(name)
+                    && (!d->exchanges[name].isNull()))
+        return d->exchanges[name].data();
 
     QAmqpExchange *exchange = new QAmqpExchange(channelNumber, this);
     d->methodHandlersByChannel[exchange->channelNumber()].append(exchange->d_func());
@@ -684,8 +685,9 @@ QAmqpQueue *QAmqpClient::createQueue(int channelNumber)
 QAmqpQueue *QAmqpClient::createQueue(const QString &name, int channelNumber)
 {
     Q_D(QAmqpClient);
-    if (!name.isEmpty() && d->queues.contains(name))
-        return d->queues[name];
+    if (!name.isEmpty() && d->queues.contains(name)
+                    && (!d->queues[name].isNull()))
+        return d->queues[name].data();
 
     QAmqpQueue *queue = new QAmqpQueue(channelNumber, this);
     d->methodHandlersByChannel[queue->channelNumber()].append(queue->d_func());

--- a/src/qamqpclient.h
+++ b/src/qamqpclient.h
@@ -133,6 +133,7 @@ private:
     Q_PRIVATE_SLOT(d_func(), void _q_heartbeat())
     Q_PRIVATE_SLOT(d_func(), void _q_connect())
     Q_PRIVATE_SLOT(d_func(), void _q_disconnect())
+    Q_PRIVATE_SLOT(d_func(), void _q_objectDestroyed())
 
     friend class QAmqpChannelPrivate;
     friend class QAmqpQueuePrivate;

--- a/src/qamqpclient.h
+++ b/src/qamqpclient.h
@@ -133,7 +133,6 @@ private:
     Q_PRIVATE_SLOT(d_func(), void _q_heartbeat())
     Q_PRIVATE_SLOT(d_func(), void _q_connect())
     Q_PRIVATE_SLOT(d_func(), void _q_disconnect())
-    Q_PRIVATE_SLOT(d_func(), void _q_objectDestroyed())
 
     friend class QAmqpChannelPrivate;
     friend class QAmqpQueuePrivate;

--- a/src/qamqpclient_p.h
+++ b/src/qamqpclient_p.h
@@ -51,6 +51,11 @@ public:
     virtual void _q_connect();
     void _q_disconnect();
 
+    /*!
+     * Iterate through our list of objects and clean up the NULL pointers.
+     */
+    void _q_objectDestroyed();
+
     virtual bool _q_method(const QAmqpMethodFrame &frame);
 
     // method handlers, FROM server

--- a/src/qamqpclient_p.h
+++ b/src/qamqpclient_p.h
@@ -101,10 +101,10 @@ public:
     QString errorString;
 
     /*! Exchange objects */
-    QHash<QString, QAmqpExchange*> exchanges;
+    QHash<QString, QPointer<QAmqpExchange> > exchanges;
 
     /*! Named queue objects */
-    QHash<QString, QAmqpQueue*> queues;
+    QHash<QString, QPointer<QAmqpQueue> > queues;
 
     QAmqpClient * const q_ptr;
     Q_DECLARE_PUBLIC(QAmqpClient)

--- a/src/qamqpclient_p.h
+++ b/src/qamqpclient_p.h
@@ -7,6 +7,7 @@
 #include <QAbstractSocket>
 #include <QSslError>
 
+#include "qamqpchannelhash_p.h"
 #include "qamqpglobal.h"
 #include "qamqpauthenticator.h"
 #include "qamqptable.h"
@@ -50,11 +51,6 @@ public:
     void _q_heartbeat();
     virtual void _q_connect();
     void _q_disconnect();
-
-    /*!
-     * Iterate through our list of objects and clean up the NULL pointers.
-     */
-    void _q_objectDestroyed();
 
     virtual bool _q_method(const QAmqpMethodFrame &frame);
 
@@ -106,10 +102,10 @@ public:
     QString errorString;
 
     /*! Exchange objects */
-    QHash<QString, QPointer<QAmqpExchange> > exchanges;
+    QAmqpChannelHash exchanges;
 
     /*! Named queue objects */
-    QHash<QString, QPointer<QAmqpQueue> > queues;
+    QAmqpChannelHash queues;
 
     QAmqpClient * const q_ptr;
     Q_DECLARE_PUBLIC(QAmqpClient)

--- a/src/qamqpclient_p.h
+++ b/src/qamqpclient_p.h
@@ -100,6 +100,12 @@ public:
     QAMQP::Error error;
     QString errorString;
 
+    /*! Exchange objects */
+    QHash<QString, QAmqpExchange*> exchanges;
+
+    /*! Named queue objects */
+    QHash<QString, QAmqpQueue*> queues;
+
     QAmqpClient * const q_ptr;
     Q_DECLARE_PUBLIC(QAmqpClient)
 

--- a/src/src.pro
+++ b/src/src.pro
@@ -33,6 +33,7 @@ greaterThan(NEED_GCOV_SUPPORT, 0) {
 
 PRIVATE_HEADERS += \
     qamqpchannel_p.h \
+    qamqpchannelhash_p.h \
     qamqpclient_p.h \
     qamqpexchange_p.h \
     qamqpframe_p.h \
@@ -56,6 +57,7 @@ HEADERS += \
 SOURCES += \
     qamqpauthenticator.cpp \
     qamqpchannel.cpp \
+    qamqpchannelhash.cpp \
     qamqpclient.cpp \
     qamqpexchange.cpp \
     qamqpframe.cpp \

--- a/tests/auto/qamqpexchange/tst_qamqpexchange.cpp
+++ b/tests/auto/qamqpexchange/tst_qamqpexchange.cpp
@@ -209,6 +209,7 @@ void tst_QAMQPExchange::cleanupOnDeletion()
     QVERIFY(waitForSignal(exchange, SIGNAL(declared())));
     exchange->close();
     exchange->deleteLater();
+    QVERIFY(waitForSignal(exchange, SIGNAL(destroyed())));
 
     // now create, declare, and close the right way
     exchange = client->createExchange("test-deletion");

--- a/tests/auto/qamqpexchange/tst_qamqpexchange.cpp
+++ b/tests/auto/qamqpexchange/tst_qamqpexchange.cpp
@@ -129,6 +129,12 @@ void tst_QAMQPExchange::invalidRedeclaration()
     // this is for rabbitmq:
     QCOMPARE(redeclared->error(), QAMQP::PreconditionFailedError);
 
+    // Server has probably closed the channel on us, if so, re-open it.
+    if (!exchange->isOpen()) {
+        exchange->reopen();
+        QVERIFY(waitForSignal(exchange, SIGNAL(opened())));
+    }
+
     // cleanup
     exchange->remove();
     QVERIFY(waitForSignal(exchange, SIGNAL(removed())));

--- a/tests/auto/qamqpqueue/tst_qamqpqueue.cpp
+++ b/tests/auto/qamqpqueue/tst_qamqpqueue.cpp
@@ -683,6 +683,7 @@ void tst_QAMQPQueue::cleanupOnDeletion()
     QVERIFY(waitForSignal(queue, SIGNAL(declared())));
     queue->close();
     queue->deleteLater();
+    QVERIFY(waitForSignal(queue, SIGNAL(destroyed())));
 
     // now create, declare, and close the right way
     queue = client->createQueue("test-deletion");


### PR DESCRIPTION
Rather than handing out "new" exchange and queue objects, we conserve memory and channel usage by keeping a list of existing objects.

If an object is asked for by name, we look for the existing object of that name first before declaring a new one.  When a queue is asked for without a name, we wait until it is declared (thus given a name by the broker) before we store it.

For exchanges, all exchanges are stored by name: NULL `QStrings` are converted to an empty string to avoid having duplicate references to the "nameless" exchange.