### PR TITLE
QAmqpExchange: Clear unconfirmedDeliveryTags on _q_disconnect().

### DIFF
--- a/src/qamqpexchange.cpp
+++ b/src/qamqpexchange.cpp
@@ -136,6 +136,7 @@ void QAmqpExchangePrivate::_q_disconnected()
     qAmqpDebug() << "exchange " << name << " disconnected";
     delayedDeclare = false;
     declared = false;
+    unconfirmedDeliveryTags.clear();
 }
 
 void QAmqpExchangePrivate::basicReturn(const QAmqpMethodFrame &frame)


### PR DESCRIPTION
This fixes an issue with allMessagesDelivered signal. The signal was not emitted after message confirms when client was reconnected after socket error.