### PR TITLE
Update src.pro

### DIFF
--- a/qamqp.pri
+++ b/qamqp.pri
@@ -7,6 +7,9 @@ isEmpty(QAMQP_LIBRARY_TYPE) {
 QT += network
 QAMQP_INCLUDEPATH = $${PWD}/src
 QAMQP_LIBS = -lqamqp
+CONFIG(debug, debug|release){
+    QAMQP_LIBS = -lqamqpd
+}
 contains(QAMQP_LIBRARY_TYPE, staticlib) {
     DEFINES += QAMQP_STATIC
 } else {

--- a/src/src.pro
+++ b/src/src.pro
@@ -3,6 +3,9 @@ include(../qamqp.pri)
 INCLUDEPATH += .
 TEMPLATE = lib
 TARGET = qamqp
+build_pass:CONFIG(debug, debug|release) {
+    TARGET = $$join(TARGET,,,d)
+}
 QT += core network
 QT -= gui
 DEFINES += QAMQP_BUILD


### PR DESCRIPTION
@mbroadst @fuCtor I consider this change very useful:
For build debug and release.
After you include qamqpInterface.pri,
you will link debug and release library depending on the current qmake build configuration.