### PR TITLE
timestamp in AMQP-0-9-1 should be seconds other than milliseconds

### DIFF
--- a/src/qamqpframe.cpp
+++ b/src/qamqpframe.cpp
@@ -202,7 +202,7 @@ QVariant QAmqpFrame::readAmqpField(QDataStream &s, QAmqpMetaType::ValueType type
     {
         qulonglong tmp_value;
         s >> tmp_value;
-        return QDateTime::fromMSecsSinceEpoch(tmp_value);
+        return QDateTime::fromTime_t(tmp_value);
     }
     case QAmqpMetaType::Hash:
     {
@@ -256,7 +256,7 @@ void QAmqpFrame::writeAmqpField(QDataStream &s, QAmqpMetaType::ValueType type, c
     }
         break;
     case QAmqpMetaType::Timestamp:
-        s << qulonglong(value.toDateTime().toMSecsSinceEpoch());
+        s << qulonglong(value.toDateTime().toTime_t());
         break;
     case QAmqpMetaType::Hash:
     {


### PR DESCRIPTION
As per the spec of AMQP 0-9-1, the timestamp value should be :

4.2.5.4 Timestamps
Time stamps are held in the 64-bit POSIX time_t format with an accuracy of one second. By using 64 bits
we avoid future wraparound issues associated with 31-bit and 32-bit time_t values.

So the qampqframe.cpp should be changed as the commit 

Thanks,
John Zhang