### PR TITLE
Add message headers getter

### DIFF
--- a/src/qamqpmessage.cpp
+++ b/src/qamqpmessage.cpp
@@ -108,6 +108,11 @@ QVariant QAmqpMessage::header(const QString &header, const QVariant &defaultValu
     return d->headers.value(header, defaultValue);
 }
 
+const QHash<QString, QVariant>& QAmqpMessage::headers() const
+{
+    return d->headers;
+}
+
 #if QT_VERSION < 0x050000
 bool QAmqpMessage::isDetached() const
 {

--- a/src/qamqpmessage.cpp
+++ b/src/qamqpmessage.cpp
@@ -108,7 +108,7 @@ QVariant QAmqpMessage::header(const QString &header, const QVariant &defaultValu
     return d->headers.value(header, defaultValue);
 }
 
-const QHash<QString, QVariant>& QAmqpMessage::headers() const
+QHash<QString, QVariant> QAmqpMessage::headers() const
 {
     return d->headers;
 }

--- a/src/qamqpmessage.h
+++ b/src/qamqpmessage.h
@@ -67,6 +67,7 @@ public:
     bool hasHeader(const QString &header) const;
     void setHeader(const QString &header, const QVariant &value);
     QVariant header(const QString &header, const QVariant &defaultValue = QVariant()) const;
+    const QHash<QString, QVariant>& headers() const;
 
     bool isValid() const;
     bool isRedelivered() const;

--- a/src/qamqpmessage.h
+++ b/src/qamqpmessage.h
@@ -67,7 +67,7 @@ public:
     bool hasHeader(const QString &header) const;
     void setHeader(const QString &header, const QVariant &value);
     QVariant header(const QString &header, const QVariant &defaultValue = QVariant()) const;
-    const QHash<QString, QVariant>& headers() const;
+    QHash<QString, QVariant> headers() const;
 
     bool isValid() const;
     bool isRedelivered() const;


### PR DESCRIPTION
Added a getter on message headers. This is usefull to explore the list of all headers within a message (example : for debuging purpose)