### PR TITLE
Fix of the issue "QAbstractSocket::connectToHost() called when already looking up or connecting/connected to xxxx"

### DIFF
--- a/src/qamqpclient.cpp
+++ b/src/qamqpclient.cpp
@@ -138,6 +138,7 @@ void QAmqpClientPrivate::_q_connect()
     if (socket->state() != QAbstractSocket::UnconnectedState) {
         qAmqpDebug() << Q_FUNC_INFO << "socket already connected, disconnecting..";
         _q_disconnect();
+        socket->abort();
     }
 
     qAmqpDebug() << "connecting to host: " << host << ", port: " << port;

--- a/tests/auto/qamqpclient/tst_qamqpclient.cpp
+++ b/tests/auto/qamqpclient/tst_qamqpclient.cpp
@@ -319,7 +319,9 @@ void tst_QAMQPClient::networkDownThenUp()
     QVERIFY(waitForSignal(&client, SIGNAL(connected())));
     qDebug() << "Connection connected";
 
-    while (true) {
+    int i = 10; // during the 5 minutes test, please disable the ethernet connection and enabled it mannualy.
+
+    while (i > 0) {
         client.disconnectFromHost();
         if (waitForSignal(&client,SIGNAL(disconnected()))) {
             qDebug() << "Connection disconnected";
@@ -335,6 +337,8 @@ void tst_QAMQPClient::networkDownThenUp()
         }
 
         QTest::qSleep(30000);
+
+        i--;
     }
 }
 

--- a/tests/auto/qamqpclient/tst_qamqpclient.cpp
+++ b/tests/auto/qamqpclient/tst_qamqpclient.cpp
@@ -24,6 +24,7 @@ private Q_SLOTS:
     void validateUri();
     void issue38();
     void issue38_take2();
+    void networkDownThenUp();
 
 public Q_SLOTS:     // temporarily disabled
     void autoReconnect();
@@ -305,6 +306,37 @@ void tst_QAMQPClient::issue38_take2()
     QVERIFY(waitForSignal(&client,SIGNAL(disconnected())));
 }
 
+void tst_QAMQPClient::networkDownThenUp()
+{
+    QAmqpClient client;
+    client.setHost("localhost"); // this should be changed to your server OTHER THAN localhost, as we test the network connection down and up
+    client.setPort(5672);
+    client.setVirtualHost("/");
+    client.setUsername("guest");
+    client.setPassword("gutest");
+    client.setAutoReconnect(false);
+    client.connectToHost();
+    QVERIFY(waitForSignal(&client, SIGNAL(connected())));
+    qDebug() << "Connection connected";
+
+    while (true) {
+        client.disconnectFromHost();
+        if (waitForSignal(&client,SIGNAL(disconnected()))) {
+            qDebug() << "Connection disconnected";
+        } else {
+            qDebug() << "Disconnect timeout";
+        }
+
+        client.connectToHost();
+        if (waitForSignal(&client, SIGNAL(connected()))) {
+            qDebug() << "Connection connected";
+        } else {
+            qDebug() << "Connection timeout";
+        }
+
+        QTest::qSleep(30000);
+    }
+}
 
 QTEST_MAIN(tst_QAMQPClient)
 #include "tst_qamqpclient.moc"


### PR DESCRIPTION
In the test case networkDownThenUp(). If an network is down and up again, the retry of the connection will get the error "QAbstractSocket::connectToHost() called when already looking up or connecting/connected to xxxx". This will cause the reconnect fail. 

Just simply add the socket->abort() after the _q_disconnect will fix the issue. 