### PR TITLE
Fix queue declaration arguments

### DIFF
--- a/src/qamqpexchange.cpp
+++ b/src/qamqpexchange.cpp
@@ -321,7 +321,6 @@ void QAmqpExchange::publish(const QByteArray &message, const QString &routingKey
     content.setProperty(QAmqpMessage::ContentType, mimeType);
     content.setProperty(QAmqpMessage::ContentEncoding, "utf-8");
     content.setProperty(QAmqpMessage::Headers, headers);
-    content.setProperty(QAmqpMessage::MessageId, "0");
 
     QAmqpMessage::PropertyHash::ConstIterator it;
     QAmqpMessage::PropertyHash::ConstIterator itEnd = properties.constEnd();

--- a/src/qamqpqueue.cpp
+++ b/src/qamqpqueue.cpp
@@ -263,8 +263,8 @@ void QAmqpQueuePrivate::declare()
     QAmqpMethodFrame frame(QAmqpFrame::Queue, QAmqpQueuePrivate::miDeclare);
     frame.setChannel(channelNumber);
 
-    QByteArray arguments;
-    QDataStream out(&arguments, QIODevice::WriteOnly);
+    QByteArray args;
+    QDataStream out(&args, QIODevice::WriteOnly);
 
     out << qint16(0);   //reserved 1
     QAmqpFrame::writeAmqpField(out, QAmqpMetaType::ShortString, name);
@@ -276,7 +276,7 @@ void QAmqpQueuePrivate::declare()
                options & QAmqpQueue::Exclusive, options & QAmqpQueue::AutoDelete,
                options & QAmqpQueue::NoWait);
 
-    frame.setArguments(arguments);
+    frame.setArguments(args);
     sendFrame(frame);
 
     if (delayedDeclare)


### PR DESCRIPTION
Hi,

Thanks for your work.
I encountered a bug when trying to declare a queue with x-max-priority = 4 set in optional arguments. The argument set didn't have any effect.
I fixed the issue in the code (variable name clash).

Best regards,
Thomas