### PR TITLE
Method reset() added to a QAmqpChannel class

### DIFF
--- a/src/qamqpchannel.cpp
+++ b/src/qamqpchannel.cpp
@@ -341,6 +341,12 @@ qint16 QAmqpChannel::prefetchCount() const
     return d->prefetchCount;
 }
 
+void QAmqpChannel::reset()
+{
+    Q_D(QAmqpChannel);
+    d->resetInternalState();
+}
+
 QAMQP::Error QAmqpChannel::error() const
 {
     Q_D(const QAmqpChannel);

--- a/src/qamqpchannel.h
+++ b/src/qamqpchannel.h
@@ -44,6 +44,8 @@ public:
     qint32 prefetchSize() const;
     qint16 prefetchCount() const;
 
+    void reset();
+
     // AMQP Basic
     void qos(qint16 prefetchCount, qint32 prefetchSize = 0);
 


### PR DESCRIPTION
Sometimes user needs to reset the channel state, for example in case of
attempt to declare an exisiting queue.