### PR TITLE
Reconnect fix.

### DIFF
--- a/src/qamqpclient.cpp
+++ b/src/qamqpclient.cpp
@@ -938,10 +938,9 @@ void QAmqpClient::disconnectFromHost()
     d->_q_disconnect();
 }
 
-void QAmqpClient::forceDisconnectFromHost()
+void QAmqpClient::abort()
 {
     Q_D(QAmqpClient);
-    d->_q_disconnect();
     d->closeConnection();
 }
 

--- a/src/qamqpclient.h
+++ b/src/qamqpclient.h
@@ -108,6 +108,7 @@ public:
     void connectToHost(const QString &uri = QString());
     void connectToHost(const QHostAddress &address, quint16 port = AMQP_PORT);
     void disconnectFromHost();
+    void forceDisconnectFromHost();
 
 Q_SIGNALS:
     void connected();

--- a/src/qamqpclient.h
+++ b/src/qamqpclient.h
@@ -108,7 +108,7 @@ public:
     void connectToHost(const QString &uri = QString());
     void connectToHost(const QHostAddress &address, quint16 port = AMQP_PORT);
     void disconnectFromHost();
-    void forceDisconnectFromHost();
+    void abort();
 
 Q_SIGNALS:
     void connected();

--- a/src/qamqpclient_p.h
+++ b/src/qamqpclient_p.h
@@ -44,6 +44,8 @@ public:
     void parseConnectionString(const QString &uri);
     void sendFrame(const QAmqpFrame &frame);
 
+    void closeConnection();
+
     // private slots
     void _q_socketConnected();
     void _q_socketDisconnected();
@@ -95,6 +97,7 @@ public:
     bool closed;
     bool connected;
     QPointer<QTimer> heartbeatTimer;
+    QPointer<QTimer> reconnectTimer;
     QAmqpTable customProperties;
     qint16 channelMax;
     qint16 heartbeatDelay;


### PR DESCRIPTION
- Adds forceDisconnectFromHost() method to QAmqpClient to immediately disconnect underlying socket;
- Fixes issue when one calls disconnectFromHost while reconnectTimer is alive;
- Properly disconnects underlying socket before another connectToHost call when socket is already connected.