### PR TITLE
Update qamqpframe.cpp

### DIFF
--- a/src/qamqpframe.cpp
+++ b/src/qamqpframe.cpp
@@ -73,7 +73,6 @@ QDataStream &operator<<(QDataStream &stream, const QAmqpFrame &frame)
 
     // write end
     stream << qint8(QAmqpFrame::FRAME_END);
-    stream.device()->waitForBytesWritten(QAmqpFrame::writeTimeout());
     return stream;
 }
 

--- a/src/qamqpframe.cpp
+++ b/src/qamqpframe.cpp
@@ -73,6 +73,13 @@ QDataStream &operator<<(QDataStream &stream, const QAmqpFrame &frame)
 
     // write end
     stream << qint8(QAmqpFrame::FRAME_END);
+    
+    int writeTimeout = QAmqpFrame::writeTimeout();
+    if(writeTimeout >= -1)
+    {
+        stream.device()->waitForBytesWritten(writeTimeout);
+    }
+
     return stream;
 }
 


### PR DESCRIPTION
I have a problem with method waitForBytesWritten.
Sometimes my application is locked when is called this method (timeout expired).
Although I try to modify writeTimeout (i.e. -1; 5 or 30), when timeout expires, rabbitMQ server disconnects me.

But if I try to delete it, it works!
My question is:
Why is this method necessary? What is its purpose?

Thank you!