### PR TITLE
src/qamqpexchange: add support for rejected/nacked deliveries

### DIFF
--- a/src/qamqpexchange.h
+++ b/src/qamqpexchange.h
@@ -80,6 +80,10 @@ Q_SIGNALS:
 
     void confirmsEnabled();
     void allMessagesDelivered();
+    void messageDeliveryFinished(const QVector<qlonglong> &rejectedDeliveryTags);
+
+    void deliveryConfirmed(qlonglong deliveryTag);
+    void deliveryRejected(qlonglong deliveryTag);
 
 public Q_SLOTS:
     // AMQP Exchange
@@ -92,13 +96,21 @@ public Q_SLOTS:
     void remove(int options = roIfUnused|roNoWait);
 
     // AMQP Basic
-    void publish(const QString &message, const QString &routingKey,
+
+    qlonglong publish(const QString &message, const QString &routingKey,
                  const QAmqpMessage::PropertyHash &properties = QAmqpMessage::PropertyHash(),
                  int publishOptions = poNoOptions);
-    void publish(const QByteArray &message, const QString &routingKey, const QString &mimeType,
+
+    qlonglong publish(const QByteArray &message, const QString &routingKey, const QString &mimeType,
                  const QAmqpMessage::PropertyHash &properties = QAmqpMessage::PropertyHash(),
                  int publishOptions = poNoOptions);
-    void publish(const QByteArray &message, const QString &routingKey,
+
+    /**
+     * Publish a message.
+     * @returns The delivery tag which can be used to identify the messsage for success/failure signals
+     * if confirms are enabled. Otherwise returns 0.
+     */
+    qlonglong publish(const QByteArray &message, const QString &routingKey,
                  const QString &mimeType, const QAmqpTable &headers,
                  const QAmqpMessage::PropertyHash &properties = QAmqpMessage::PropertyHash(),
                  int publishOptions = poNoOptions);

--- a/src/qamqpexchange_p.h
+++ b/src/qamqpexchange_p.h
@@ -30,7 +30,8 @@ public:
     void declareOk(const QAmqpMethodFrame &frame);
     void deleteOk(const QAmqpMethodFrame &frame);
     void basicReturn(const QAmqpMethodFrame &frame);
-    void handleAckOrNack(const QAmqpMethodFrame &frame);
+    void handlePublishReply(const QAmqpMethodFrame &frame);
+    QVector<qlonglong> takeUnconfirmedDeliveryTags(qlonglong deliveryTag, bool multiple);
 
     QString type;
     QAmqpExchange::ExchangeOptions options;
@@ -38,6 +39,7 @@ public:
     bool declared;
     qlonglong nextDeliveryTag;
     QVector<qlonglong> unconfirmedDeliveryTags;
+    QVector<qlonglong> rejectedDeliveryTags;
 
     Q_DECLARE_PUBLIC(QAmqpExchange)
 };

--- a/tests/auto/qamqpexchange/tst_qamqpexchange.cpp
+++ b/tests/auto/qamqpexchange/tst_qamqpexchange.cpp
@@ -28,6 +28,7 @@ private Q_SLOTS:
     void passiveDeclareNotFound();
     void cleanupOnDeletion();
     void testQueuedPublish();
+    void testRejectedMessagePublish();
 
 private:
     QScopedPointer<QAmqpClient> client;
@@ -231,6 +232,10 @@ void tst_QAMQPExchange::testQueuedPublish()
     defaultExchange->enableConfirms();
     QVERIFY(waitForSignal(defaultExchange, SIGNAL(confirmsEnabled())));
 
+    SignalSpy deliveryConfirmedSpy(defaultExchange, SIGNAL(deliveryConfirmed(qlonglong)));
+    SignalSpy allMessagesDeliveredSpy(defaultExchange, SIGNAL(allMessagesDelivered()));
+    SignalSpy messageDeliveryFinishedSpy(defaultExchange, SIGNAL(messageDeliveryFinished(QVector<qlonglong>)));
+
     QAmqpMessage::PropertyHash properties;
     properties[QAmqpMessage::DeliveryMode] = "2";   // make message persistent
     for (int i = 0; i < 10000; ++i) {
@@ -240,6 +245,56 @@ void tst_QAMQPExchange::testQueuedPublish()
     }
 
     QVERIFY(defaultExchange->waitForConfirms());
+
+    QCOMPARE(allMessagesDeliveredSpy.count(), 1);
+
+    QCOMPARE(messageDeliveryFinishedSpy.count(), 1);
+    QVector< qlonglong > rejectedDeliveryTags = messageDeliveryFinishedSpy.first().first().value< QVector< qlonglong > >();
+    QVERIFY(rejectedDeliveryTags.isEmpty());
+
+    QCOMPARE(deliveryConfirmedSpy.count(), 10000);
+    for (int i = 0; i < 10000; ++i) {
+        qlonglong deliveryTag = deliveryConfirmedSpy.at(i).first().toLongLong();
+        QCOMPARE(deliveryTag, i+1);
+      }
+}
+
+void tst_QAMQPExchange::testRejectedMessagePublish()
+{
+    QAmqpTable queueArguments;
+    queueArguments["x-max-length"] = 1;  // queue can only accept one message!
+    queueArguments["x-overflow"] = "reject-publish";  // more messages will be rejected
+    QAmqpQueue *queue = client->createQueue("small_queue");
+    queue->declare(QAmqpQueue::Exclusive | QAmqpQueue::AutoDelete, queueArguments);
+    QVERIFY(waitForSignal(queue, SIGNAL(declared())));
+
+    QAmqpExchange *exchange = client->createExchange();
+    exchange->enableConfirms();
+    QVERIFY(waitForSignal(exchange, SIGNAL(confirmsEnabled())));
+
+    SignalSpy deliveryConfirmedSpy(exchange, SIGNAL(deliveryConfirmed(qlonglong)));
+    SignalSpy deliveryRejectedSpy(exchange, SIGNAL(deliveryRejected(qlonglong)));
+    SignalSpy allMessagesDeliveredSpy(exchange, SIGNAL(allMessagesDelivered()));
+    SignalSpy messageDeliveryFinishedSpy(exchange, SIGNAL(messageDeliveryFinished(QVector<qlonglong>)));
+
+    qlonglong firstDeliveryTag = exchange->publish("message", "small_queue");
+    qlonglong secondDeliveryTag = exchange->publish("message", "small_queue");
+    QVERIFY(firstDeliveryTag != secondDeliveryTag);
+
+    QVERIFY(exchange->waitForConfirms());
+
+    QCOMPARE(deliveryConfirmedSpy.count(), 1);
+    QCOMPARE(deliveryConfirmedSpy.first().first().toLongLong(), firstDeliveryTag);
+
+    QCOMPARE(deliveryRejectedSpy.count(), 1);
+    QCOMPARE(deliveryRejectedSpy.first().first().toLongLong(), secondDeliveryTag);
+
+    QCOMPARE(allMessagesDeliveredSpy.count(), 0); // not all messages were delivered
+
+    QCOMPARE(messageDeliveryFinishedSpy.count(), 1);
+    QVector< qlonglong > rejectedDeliveryTags = messageDeliveryFinishedSpy.first().first().value< QVector< qlonglong > >();
+    QCOMPARE(rejectedDeliveryTags.count(), 1);
+    QCOMPARE(rejectedDeliveryTags.first(), secondDeliveryTag);
 }
 
 QTEST_MAIN(tst_QAMQPExchange)


### PR DESCRIPTION
In case the queue has a message count/size limit (config "x-max-length"),
rabbitmq can be configured to nack/reject publishing messages when the
queue is full (config "x-overflow":"reject-publish").

In this setup, qamqp exchange only does a log and skips the nack message,
which leads to these delivery tags are never removed from
unconfirmedDeliveryTags vector, therefor allMessagesDelivered signal
will never trigger.

To make the library user be able to handle this (but try to maintain
compatibility), I have added an extra signal (messageDeliveryFinished)
which is also sent when rejected/nacked messages remained, identifying
the nacked messages by their delivery tags.

Also added direct signals for publish confirms / rejects, because handling
nack/reject is often just a retry of the publish after some time. This requires
storing the messages until they are confirmed. For some use cases keeping
all messages in memory until there is a point when all waiting publishes
gets confirmed is a waste of resources or not feasible at all (no time when
all is confirmed).

See https://www.rabbitmq.com/maxlength.html and
https://www.rabbitmq.com/confirms.html#server-sent-nacks