### PR TITLE
Fix sending short/long Unicode strings

### DIFF
--- a/src/qamqpframe.cpp
+++ b/src/qamqpframe.cpp
@@ -250,20 +250,20 @@ void QAmqpFrame::writeAmqpField(QDataStream &s, QAmqpMetaType::ValueType type, c
         break;
     case QAmqpMetaType::ShortString:
     {
-        QString str = value.toString();
+        QByteArray str = value.toString().toUtf8();
         if (str.length() >= 256) {
             qAmqpDebug() << Q_FUNC_INFO << "invalid shortstr length: " << str.length();
         }
 
         s << quint8(str.length());
-        s.writeRawData(str.toUtf8().data(), str.length());
+        s.writeRawData(str.data(), str.length());
     }
         break;
     case QAmqpMetaType::LongString:
     {
-        QString str = value.toString();
+        QByteArray str = value.toString().toLatin1();
         s << quint32(str.length());
-        s.writeRawData(str.toLatin1().data(), str.length());
+        s.writeRawData(str.data(), str.length());
     }
         break;
     case QAmqpMetaType::Timestamp:

--- a/tests/auto/qamqpqueue/tst_qamqpqueue.cpp
+++ b/tests/auto/qamqpqueue/tst_qamqpqueue.cpp
@@ -48,6 +48,7 @@ private Q_SLOTS:
     void tableFieldDataTypes();
     void messageProperties();
     void emptyMessage();
+    void sendUnicodeString();
     void cleanupOnDeletion();
 
 private:
@@ -684,6 +685,17 @@ void tst_QAMQPQueue::emptyMessage()
     QAmqpMessage message = queue->dequeue();
     verifyStandardMessageHeaders(message, "test-issue-43");
     QVERIFY(message.payload().isEmpty());
+}
+
+void tst_QAMQPQueue::sendUnicodeString()
+{
+  QAmqpQueue *queue = client->createQueue("テストファイル");
+  queue->declare();
+  QVERIFY(waitForSignal(queue, SIGNAL(declared())));
+
+  // clean up queue
+  queue->remove(QAmqpQueue::roForce);
+  QVERIFY(waitForSignal(queue, SIGNAL(removed())));
 }
 
 void tst_QAMQPQueue::cleanupOnDeletion()


### PR DESCRIPTION
- Convert to utf8 _before_ writing string so string and string length match